### PR TITLE
fix: SSE keepalive 추가 - 프록시 idle timeout 방지

### DIFF
--- a/deep-insight-web/README.md
+++ b/deep-insight-web/README.md
@@ -12,7 +12,7 @@ Web UI for Deep Insight — a FastAPI server that connects to the Managed AgentC
 
 - **Browser-Based**: Upload data, review plans, download reports — no CLI needed
 - **Bilingual**: Korean / English language support
-- **Secure**: Internet-facing ALB restricted to VPN CIDR
+- **Secure**: Two deployment options — VPN CIDR or CloudFront + Cognito auth
 
 <img src="../docs/front-end/images/web-ui.png" alt="Deep Insight Web UI" width="600"/>
 
@@ -29,15 +29,25 @@ Web UI for Deep Insight — a FastAPI server that connects to the Managed AgentC
 
 > **Important**: The Web UI requires a running Managed AgentCore deployment. The `managed-agentcore/.env` file must exist with `RUNTIME_ARN`, `AWS_REGION`, and `S3_BUCKET_NAME` configured.
 
-### Production Deployment
+### Deployment Options
+
+Two deployment methods are available:
+
+| | Option A: VPN CIDR | Option B: CloudFront + Cognito |
+|---|---------------------|-------------------------------|
+| **Script** | `deploy.sh` | `deploy-cloudfront.sh` |
+| **Access** | VPN users only | Anyone with Cognito credentials |
+| **ALB SG** | VPN CIDR inbound | CloudFront managed prefix list |
+| **Auth** | Network-level (VPN) | Cognito User Pool (Lambda@Edge) |
+| **HTTPS** | No (HTTP via VPN) | Yes (CloudFront terminates TLS) |
+| **Best for** | Internal teams on VPN | External demos, customer PoCs |
+
+### Option A: VPN CIDR (direct ALB)
 
 ```bash
 cd deep-insight-web
 
-# Deploy (ECR, Docker build/push, ALB, ECS)
-# VPN_CIDR restricts ALB access to your VPN's IP range (only users on the VPN can reach the Web UI)
-# Usage: bash deploy.sh <VPN_CIDR>
-# Example: bash deploy.sh "10.0.0.0/8"
+# Deploy with VPN CIDR restriction
 bash deploy.sh "<YOUR_VPN_CIDR>"
 
 # Wait for service to stabilize
@@ -46,24 +56,48 @@ aws ecs wait services-stable \
   --services deep-insight-web-service \
   --region us-west-2
 
-# Clean up all resources
+# Clean up
 bash deploy.sh cleanup
 ```
 
+### Option B: CloudFront + Cognito (recommended)
+
+```bash
+cd deep-insight-web
+
+# Deploy with CloudFront (ALB restricted to CloudFront prefix list only)
+bash deploy-cloudfront.sh
+
+# Wait for service to stabilize
+aws ecs wait services-stable \
+  --cluster deep-insight-cluster-prod \
+  --services deep-insight-web-service \
+  --region us-west-2
+
+# (Optional) Add Cognito authentication
+bash add-cognito-auth.sh <CLOUDFRONT_DISTRIBUTION_ID>
+
+# Clean up (removes CloudFront, ALB, ECS, and all resources)
+bash deploy-cloudfront.sh cleanup
+```
+
+> **Security**: `deploy-cloudfront.sh` uses the CloudFront managed prefix list (`pl-82a045eb`) instead of `0.0.0.0/0` for the ALB security group. This prevents DyePack/Epoxy auto-mitigation incidents.
+
 > **Note**: Do NOT test during rolling deployment — the old ECS task gets killed mid-stream.
 
-### What `deploy.sh` Does
+### What the deploy scripts do
 
-The script handles all infrastructure in a single run:
+Both scripts handle all infrastructure in a single run:
 
 1. **ECR Repository** — Creates container registry
-2. **Docker Build + Push** — Builds image natively (arm64 on Graviton, x86 on Intel) and pushes to ECR
-3. **Security Groups** — ALB SG (VPN CIDR inbound on port 80), ECS SG, VPC endpoint rules
+2. **Docker Build + Push** — Auto-detects platform (arm64/x86) and pushes to ECR
+3. **Security Groups** — ALB SG (VPN CIDR *or* CloudFront prefix list), ECS SG, VPC endpoint rules
 4. **ALB + Target Group + Listener** — Internet-facing ALB with 3600s idle timeout for long analysis sessions
 5. **IAM Task Role** — Least-privilege permissions (S3 upload/feedback/artifacts, AgentCore invoke)
 6. **CloudWatch Log Group** — Container logging
-7. **ECS Task Definition** — Fargate ARM64 (Graviton2), 256 CPU / 512 MB
+7. **ECS Task Definition** — Fargate (auto-detects ARM64 or X86_64), 256 CPU / 512 MB
 8. **ECS Service** — Creates or updates with rolling deployment
+9. **CloudFront** — *(Option B only)* Creates distribution with ALB origin
 
 ---
 
@@ -87,17 +121,30 @@ The script handles all infrastructure in a single run:
 
 ## Architecture
 
+**Option A: VPN CIDR**
+
 ```
-Browser ←─ SSE ──→ FastAPI (deep-insight-web)
-                        │
-                        ├── boto3.invoke_agent_runtime() ──→ AgentCore Runtime
-                        │        (SSE streaming, 3600s timeout)
-                        │
-                        └── S3 ──→ File upload / HITL feedback / Report download
+Browser --> ALB (VPN CIDR SG) --> ECS Fargate (FastAPI)
+                                      |
+                                      +-- AgentCore Runtime (SSE streaming)
+                                      +-- S3 (upload / feedback / artifacts)
+```
+
+**Option B: CloudFront + Cognito**
+
+```
+Browser --> CloudFront (HTTPS) --> Lambda@Edge (Cognito auth)
+                                       |
+                                       v (authenticated)
+                                  ALB (CF prefix list SG) --> ECS Fargate (FastAPI)
+                                                                  |
+                                                                  +-- AgentCore Runtime
+                                                                  +-- S3
 ```
 
 - **AgentCore Native Protocol**: `boto3.invoke_agent_runtime()` with SSE streaming
-- **HITL flow**: `plan_review_request` SSE event → browser modal → `POST /feedback` → S3 → AgentCore polls
+- **SSE keepalive**: Sends `: keepalive` comments every 30s to prevent proxy idle timeout
+- **HITL flow**: `plan_review_request` SSE event -> browser modal -> `POST /feedback` -> S3 -> AgentCore polls
 - **Env vars**: Reuses `managed-agentcore/.env` (no separate `.env.example`)
 
 ---

--- a/deep-insight-web/add-cognito-auth.sh
+++ b/deep-insight-web/add-cognito-auth.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================
+# add-cognito-auth.sh — Attach Cognito Lambda@Edge to CloudFront
+#
+# Associates a pre-deployed Cognito Lambda@Edge function with a
+# CloudFront distribution for authentication. Also registers the
+# CloudFront domain as a callback URL in the Cognito app client.
+#
+# Prerequisites:
+#   - Cognito User Pool with Lambda@Edge function deployed
+#     (e.g., via CDK stack in a separate Cognito project)
+#   - Lambda@Edge must be in us-east-1 (CloudFront requirement)
+#   - Lambda must have a published version (not $LATEST)
+#
+# Usage:
+#   bash add-cognito-auth.sh <distribution-id> [lambda-arn] [user-pool-id] [client-id]
+#
+# Examples:
+#   bash add-cognito-auth.sh E1234567890ABC
+#   bash add-cognito-auth.sh E1234567890ABC arn:aws:lambda:us-east-1:123:function:auth:1
+#
+# Environment variables (override defaults):
+#   COGNITO_LAMBDA_ARN    - Lambda@Edge version ARN
+#   COGNITO_USER_POOL_ID  - Cognito User Pool ID
+#   COGNITO_CLIENT_ID     - Cognito App Client ID
+#   COGNITO_REGION        - Cognito region (default: us-east-1)
+# ============================================================
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <distribution-id> [lambda-arn] [user-pool-id] [client-id]"
+    echo ""
+    echo "Examples:"
+    echo "  $0 E1234567890ABC"
+    echo "  $0 E1234567890ABC arn:aws:lambda:us-east-1:123:function:auth:1"
+    echo ""
+    echo "Override defaults with environment variables:"
+    echo "  COGNITO_LAMBDA_ARN=... COGNITO_USER_POOL_ID=... $0 E1234567890ABC"
+    exit 1
+fi
+
+DIST_ID="$1"
+LAMBDA_VERSION_ARN="${2:-${COGNITO_LAMBDA_ARN:-}}"
+USER_POOL_ID="${3:-${COGNITO_USER_POOL_ID:-}}"
+CLIENT_ID="${4:-${COGNITO_CLIENT_ID:-}}"
+COGNITO_REGION="${COGNITO_REGION:-us-east-1}"
+
+# Auto-discover Lambda@Edge if not provided
+if [ -z "$LAMBDA_VERSION_ARN" ]; then
+    echo "Auto-discovering Lambda@Edge function..."
+    # Look for common naming patterns
+    for FUNC_NAME in "poc-cognito-auth-edge" "deep-insight-cognito-auth" "cognito-auth-edge"; do
+        ARN=$(aws lambda list-versions-by-function \
+            --function-name "$FUNC_NAME" \
+            --region "$COGNITO_REGION" \
+            --query 'Versions[-1].FunctionArn' \
+            --output text 2>/dev/null || true)
+        if [ -n "$ARN" ] && [ "$ARN" != "None" ]; then
+            LAMBDA_VERSION_ARN="$ARN"
+            echo "  Found: ${FUNC_NAME} -> ${LAMBDA_VERSION_ARN}"
+            break
+        fi
+    done
+
+    if [ -z "$LAMBDA_VERSION_ARN" ]; then
+        echo "ERROR: No Lambda@Edge function found. Provide ARN as argument or COGNITO_LAMBDA_ARN env var."
+        exit 1
+    fi
+fi
+
+# Auto-discover Cognito User Pool if not provided
+if [ -z "$USER_POOL_ID" ] || [ -z "$CLIENT_ID" ]; then
+    echo "Auto-discovering Cognito User Pool..."
+    POOLS=$(aws cognito-idp list-user-pools --max-results 10 --region "$COGNITO_REGION" \
+        --query "UserPools[?contains(Name, 'deep-insight') || contains(Name, 'poc-demo')].{Id:Id,Name:Name}" \
+        --output json 2>/dev/null || echo "[]")
+
+    POOL_ID=$(echo "$POOLS" | python3 -c "
+import json, sys
+pools = json.load(sys.stdin)
+if pools: print(pools[0]['Id'])
+else: print('')
+" 2>/dev/null || true)
+
+    if [ -n "$POOL_ID" ]; then
+        USER_POOL_ID="$POOL_ID"
+        CLIENT_ID=$(aws cognito-idp list-user-pool-clients \
+            --user-pool-id "$USER_POOL_ID" \
+            --region "$COGNITO_REGION" \
+            --query "UserPoolClients[0].ClientId" \
+            --output text 2>/dev/null || true)
+        echo "  User Pool: ${USER_POOL_ID}"
+        echo "  Client ID: ${CLIENT_ID}"
+    fi
+fi
+
+if [ -z "$USER_POOL_ID" ] || [ -z "$CLIENT_ID" ]; then
+    echo "ERROR: Cognito User Pool not found. Provide user-pool-id and client-id as arguments."
+    exit 1
+fi
+
+echo ""
+echo "============================================"
+echo "Attach Cognito Auth to CloudFront"
+echo "============================================"
+echo "Distribution:  ${DIST_ID}"
+echo "Lambda@Edge:   ${LAMBDA_VERSION_ARN}"
+echo "User Pool:     ${USER_POOL_ID}"
+echo "Client ID:     ${CLIENT_ID}"
+echo ""
+
+# Step 1: Get current distribution config
+echo "=== Step 1: Get current CloudFront config ==="
+ETAG=$(aws cloudfront get-distribution-config --id "${DIST_ID}" --query 'ETag' --output text)
+aws cloudfront get-distribution-config --id "${DIST_ID}" --query 'DistributionConfig' > /tmp/cf-config.json
+echo "  ETag: ${ETAG}"
+
+# Step 2: Add Lambda@Edge to default cache behavior
+echo "=== Step 2: Update config with Lambda@Edge ==="
+LAMBDA_ASSOC="{\"LambdaFunctionAssociations\":{\"Quantity\":1,\"Items\":[{\"LambdaFunctionARN\":\"${LAMBDA_VERSION_ARN}\",\"EventType\":\"viewer-request\",\"IncludeBody\":false}]}}"
+
+jq --argjson assoc "${LAMBDA_ASSOC}" \
+    '.DefaultCacheBehavior += $assoc' \
+    /tmp/cf-config.json > /tmp/cf-config-updated.json
+
+# Step 3: Update distribution
+echo "=== Step 3: Update CloudFront distribution ==="
+aws cloudfront update-distribution \
+    --id "${DIST_ID}" \
+    --if-match "${ETAG}" \
+    --distribution-config file:///tmp/cf-config-updated.json \
+    --no-cli-pager > /dev/null
+
+echo ""
+echo "  Done! Distribution ${DIST_ID} is being updated."
+echo "  CloudFront deployment takes 2-5 minutes."
+
+# Step 4: Add callback URL to Cognito
+echo "=== Step 4: Register CloudFront callback URL ==="
+
+CF_DOMAIN=$(aws cloudfront get-distribution --id "${DIST_ID}" \
+    --query 'Distribution.DomainName' --output text)
+
+CALLBACK="https://${CF_DOMAIN}/callback"
+LOGOUT="https://${CF_DOMAIN}"
+
+CURRENT=$(aws cognito-idp describe-user-pool-client \
+    --user-pool-id "${USER_POOL_ID}" \
+    --client-id "${CLIENT_ID}" \
+    --region "${COGNITO_REGION}")
+
+CURRENT_CALLBACKS=$(echo "${CURRENT}" | jq -r '.UserPoolClient.CallbackURLs // [] | .[]')
+
+if echo "${CURRENT_CALLBACKS}" | grep -q "${CALLBACK}"; then
+    echo "  Callback URL already registered: ${CALLBACK}"
+else
+    echo "  Adding callback URL: ${CALLBACK}"
+
+    # Build updated URL lists
+    NEW_CALLBACKS=$(echo "${CURRENT}" | jq -r '[.UserPoolClient.CallbackURLs // [] | .[]] + ["'"${CALLBACK}"'"] | join(" ")')
+    NEW_LOGOUTS=$(echo "${CURRENT}" | jq -r '[.UserPoolClient.LogoutURLs // [] | .[]] + ["'"${LOGOUT}"'"] | join(" ")')
+
+    # Ensure SupportedIdentityProviders includes COGNITO (required for Hosted UI)
+    aws cognito-idp update-user-pool-client \
+        --user-pool-id "${USER_POOL_ID}" \
+        --client-id "${CLIENT_ID}" \
+        --supported-identity-providers COGNITO \
+        --callback-urls ${NEW_CALLBACKS} \
+        --logout-urls ${NEW_LOGOUTS} \
+        --allowed-o-auth-flows code \
+        --allowed-o-auth-scopes openid email profile \
+        --allowed-o-auth-flows-user-pool-client \
+        --region "${COGNITO_REGION}" \
+        --no-cli-pager > /dev/null
+
+    echo "  Cognito callback URLs updated"
+fi
+
+# Cleanup
+rm -f /tmp/cf-config.json /tmp/cf-config-updated.json
+
+echo ""
+echo "============================================"
+echo "Cognito auth attached successfully!"
+echo "============================================"
+echo ""
+echo "URL:      https://${CF_DOMAIN}"
+echo "Sign-out: https://${CF_DOMAIN}/signout"
+echo ""
+echo "Wait 2-5 minutes for CloudFront to deploy, then test access."

--- a/deep-insight-web/app.py
+++ b/deep-insight-web/app.py
@@ -8,6 +8,8 @@ handling HITL plan review, and downloading generated reports.
 import json
 import logging
 import os
+import queue
+import threading
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -229,8 +231,35 @@ async def upload(
 # ---------- Feature 4: Analysis + SSE streaming ----------
 
 
+# SSE keepalive 주기 (초). CloudFront 기본 Origin Read Timeout(60초) 내에
+# 반드시 데이터가 전송되어야 연결이 유지됨. 30초면 충분한 여유가 있음.
+SSE_KEEPALIVE_INTERVAL = 30
+
+
+def _read_agentcore_events(response, event_queue):
+    """AgentCore SSE 스트림을 읽어서 queue에 넣는 백그라운드 스레드 함수.
+
+    iter_lines()는 blocking 호출이므로 별도 스레드에서 실행해야
+    메인 generator가 keepalive를 보낼 수 있음.
+    """
+    try:
+        for event_bytes in response["response"].iter_lines(chunk_size=1):
+            event_data = parse_sse_data(event_bytes)
+            if event_data is not None:
+                event_queue.put(event_data)
+    except Exception as e:
+        event_queue.put({"type": "error", "text": str(e)})
+    finally:
+        event_queue.put(None)  # 스트림 종료 신호
+
+
 def agentcore_sse_generator(query: str, data_directory: str, upload_id: str = ""):
-    """Call AgentCore Runtime and yield SSE events for the browser."""
+    """AgentCore Runtime을 호출하고 브라우저로 SSE 이벤트를 전송.
+
+    CloudFront/프록시 환경에서 idle timeout으로 연결이 끊기는 것을 방지하기 위해
+    SSE_KEEPALIVE_INTERVAL마다 SSE comment(": keepalive")를 전송함.
+    SSE 스펙에 의해 브라우저는 comment를 무시하므로 기능에 영향 없음.
+    """
     if not RUNTIME_ARN:
         yield format_sse({"type": "error", "text": "RUNTIME_ARN not configured"})
         return
@@ -252,10 +281,24 @@ def agentcore_sse_generator(query: str, data_directory: str, upload_id: str = ""
             yield format_sse({"type": "error", "text": f"Unexpected content type: {content_type}"})
             return
 
-        for event_bytes in response["response"].iter_lines(chunk_size=1):
-            event_data = parse_sse_data(event_bytes)
-            if event_data is None:
+        # 백그라운드 스레드에서 AgentCore 이벤트를 읽고,
+        # 메인 generator는 keepalive를 보내면서 이벤트를 전달
+        event_queue = queue.Queue()
+        reader_thread = threading.Thread(
+            target=_read_agentcore_events, args=(response, event_queue), daemon=True
+        )
+        reader_thread.start()
+
+        while True:
+            try:
+                event_data = event_queue.get(timeout=SSE_KEEPALIVE_INTERVAL)
+            except queue.Empty:
+                # 타임아웃: 실제 이벤트 없음 -> keepalive comment 전송
+                yield ": keepalive\n\n"
                 continue
+
+            if event_data is None:
+                break  # 스트림 종료
 
             event_type = event_data.get("type") or event_data.get("event_type") or "unknown"
 

--- a/deep-insight-web/app.py
+++ b/deep-insight-web/app.py
@@ -231,16 +231,16 @@ async def upload(
 # ---------- Feature 4: Analysis + SSE streaming ----------
 
 
-# SSE keepalive 주기 (초). CloudFront 기본 Origin Read Timeout(60초) 내에
-# 반드시 데이터가 전송되어야 연결이 유지됨. 30초면 충분한 여유가 있음.
+# SSE keepalive interval in seconds. Must be shorter than CloudFront's default
+# Origin Read Timeout (60s) to prevent proxy idle disconnections.
 SSE_KEEPALIVE_INTERVAL = 30
 
 
 def _read_agentcore_events(response, event_queue):
-    """AgentCore SSE 스트림을 읽어서 queue에 넣는 백그라운드 스레드 함수.
+    """Read AgentCore SSE stream in a background thread and enqueue parsed events.
 
-    iter_lines()는 blocking 호출이므로 별도 스레드에서 실행해야
-    메인 generator가 keepalive를 보낼 수 있음.
+    iter_lines() is a blocking call, so it must run in a separate thread
+    to allow the main generator to yield keepalive comments.
     """
     try:
         for event_bytes in response["response"].iter_lines(chunk_size=1):
@@ -250,15 +250,16 @@ def _read_agentcore_events(response, event_queue):
     except Exception as e:
         event_queue.put({"type": "error", "text": str(e)})
     finally:
-        event_queue.put(None)  # 스트림 종료 신호
+        event_queue.put(None)  # End-of-stream sentinel
 
 
 def agentcore_sse_generator(query: str, data_directory: str, upload_id: str = ""):
-    """AgentCore Runtime을 호출하고 브라우저로 SSE 이벤트를 전송.
+    """Call AgentCore Runtime and yield SSE events for the browser.
 
-    CloudFront/프록시 환경에서 idle timeout으로 연결이 끊기는 것을 방지하기 위해
-    SSE_KEEPALIVE_INTERVAL마다 SSE comment(": keepalive")를 전송함.
-    SSE 스펙에 의해 브라우저는 comment를 무시하므로 기능에 영향 없음.
+    To prevent proxy idle timeout disconnections (e.g., CloudFront Origin Read
+    Timeout of 60s), this generator sends an SSE comment (": keepalive") every
+    SSE_KEEPALIVE_INTERVAL seconds when no real events are available.
+    Browsers ignore SSE comments per the W3C spec, so this has no side effects.
     """
     if not RUNTIME_ARN:
         yield format_sse({"type": "error", "text": "RUNTIME_ARN not configured"})
@@ -281,8 +282,8 @@ def agentcore_sse_generator(query: str, data_directory: str, upload_id: str = ""
             yield format_sse({"type": "error", "text": f"Unexpected content type: {content_type}"})
             return
 
-        # 백그라운드 스레드에서 AgentCore 이벤트를 읽고,
-        # 메인 generator는 keepalive를 보내면서 이벤트를 전달
+        # Read events in a background thread so the main generator can
+        # yield keepalive comments during long idle periods.
         event_queue = queue.Queue()
         reader_thread = threading.Thread(
             target=_read_agentcore_events, args=(response, event_queue), daemon=True
@@ -293,14 +294,20 @@ def agentcore_sse_generator(query: str, data_directory: str, upload_id: str = ""
             try:
                 event_data = event_queue.get(timeout=SSE_KEEPALIVE_INTERVAL)
             except queue.Empty:
-                # 타임아웃: 실제 이벤트 없음 -> keepalive comment 전송
+                # No event within the interval — send SSE comment to keep
+                # the connection alive through proxies.
                 yield ": keepalive\n\n"
                 continue
 
             if event_data is None:
-                break  # 스트림 종료
+                break  # End-of-stream sentinel from reader thread
 
             event_type = event_data.get("type") or event_data.get("event_type") or "unknown"
+
+            # Track failures from the reader thread so the ops dashboard
+            # (DynamoDB job tracking) records them correctly.
+            if event_type == "error":
+                track_job_failure(upload_id, event_data.get("text", "unknown error"))
 
             if event_type == "plan_review_request":
                 yield format_sse({

--- a/deep-insight-web/deploy-cloudfront.sh
+++ b/deep-insight-web/deploy-cloudfront.sh
@@ -1,0 +1,663 @@
+#!/bin/bash
+set -e
+
+# ============================================================
+# deploy-cloudfront.sh — Deploy deep-insight-web with CloudFront
+#
+# Alternative to deploy.sh that uses CloudFront instead of VPN CIDR
+# for access control. This is the recommended approach when direct
+# VPN access is not available or when Cognito authentication is needed.
+#
+# Architecture:
+#   CloudFront (HTTPS) → ALB (CF prefix list only) → ECS (private subnet)
+#
+# Security:
+#   - ALB Security Group allows ONLY CloudFront managed prefix list
+#   - NO 0.0.0.0/0 exposure on ALB (prevents DyePack/Epoxy incidents)
+#   - Optional: Cognito auth via Lambda@Edge (see add-cognito-auth.sh)
+#
+# Prerequisites:
+#   - AWS CLI configured with appropriate permissions
+#   - Docker installed
+#   - managed-agentcore/.env populated (from Phase 1+2 deployment)
+#
+# Usage:
+#   bash deploy-cloudfront.sh              # Deploy with CloudFront
+#   bash deploy-cloudfront.sh cleanup      # Remove all resources
+#
+# After deploy:
+#   bash add-cognito-auth.sh <CF_DIST_ID>  # (Optional) Add Cognito auth
+# ============================================================
+
+export AWS_PAGER=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$(cd "$SCRIPT_DIR/../managed-agentcore" && pwd)/.env"
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "ERROR: $ENV_FILE not found. Deploy managed-agentcore first."
+    exit 1
+fi
+
+# Load env vars from managed-agentcore/.env
+set -a
+source "$ENV_FILE"
+set +a
+
+# ---------- Configuration ----------
+
+REGION="${AWS_REGION:-us-west-2}"
+ACCOUNT_ID="${AWS_ACCOUNT_ID}"
+
+# Existing resources (from managed-agentcore deployment)
+CLUSTER_NAME="${ECS_CLUSTER_NAME}"
+VPC_ID="${VPC_ID}"
+SUBNET_1="${PRIVATE_SUBNET_1_ID}"
+SUBNET_2="${PRIVATE_SUBNET_2_ID}"
+PUBLIC_SUBNET_1="${PUBLIC_SUBNET_1_ID}"
+PUBLIC_SUBNET_2="${PUBLIC_SUBNET_2_ID}"
+SG_VPCE="${SG_VPCE_ID}"
+EXECUTION_ROLE_ARN="${TASK_EXECUTION_ROLE_ARN}"
+S3_BUCKET="${S3_BUCKET_NAME}"
+RUNTIME_ARN_VALUE="${RUNTIME_ARN}"
+
+# New resources
+ECR_REPO_NAME="deep-insight-web"
+IMAGE_TAG="latest"
+ECR_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${ECR_REPO_NAME}"
+ALB_WEB_NAME="deep-insight-web-alb"
+SG_ALB_WEB_NAME="deep-insight-web-alb-sg"
+TG_NAME="deep-insight-web-tg"
+SG_WEB_NAME="deep-insight-web-ecs-sg"
+TASK_FAMILY="deep-insight-web-task"
+SERVICE_NAME="deep-insight-web-service"
+LOG_GROUP="/ecs/deep-insight-web"
+TASK_ROLE_NAME="deep-insight-web-task-role"
+TASK_ROLE_POLICY_NAME="deep-insight-web-task-policy"
+
+# CloudFront managed prefix list ID (same across all regions)
+# See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/LocationsOfEdgeServers.html
+CF_PREFIX_LIST="pl-82a045eb"
+
+echo "============================================"
+echo "Deploy deep-insight-web (CloudFront mode)"
+echo "============================================"
+echo "Region:      ${REGION}"
+echo "Account:     ${ACCOUNT_ID}"
+echo "Cluster:     ${CLUSTER_NAME}"
+echo "VPC:         ${VPC_ID}"
+echo "S3 Bucket:   ${S3_BUCKET}"
+echo "Runtime ARN: ${RUNTIME_ARN_VALUE:0:60}..."
+echo "ALB SG:      CloudFront prefix list (${CF_PREFIX_LIST})"
+echo ""
+
+# ---------- Cleanup mode ----------
+
+if [ "${1}" = "cleanup" ]; then
+    echo "=== Cleanup: Removing deep-insight-web resources (CloudFront mode) ==="
+
+    # Get CloudFront distribution ID linked to this ALB
+    ALB_WEB_DNS=$(aws elbv2 describe-load-balancers --names "$ALB_WEB_NAME" \
+        --region "$REGION" --query "LoadBalancers[0].DNSName" --output text 2>/dev/null || true)
+
+    if [ -n "$ALB_WEB_DNS" ] && [ "$ALB_WEB_DNS" != "None" ]; then
+        echo "Looking for CloudFront distributions pointing to ${ALB_WEB_DNS}..."
+        CF_DIST_ID=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?Origins.Items[?DomainName=='${ALB_WEB_DNS}']].Id" \
+            --output text 2>/dev/null || true)
+
+        if [ -n "$CF_DIST_ID" ] && [ "$CF_DIST_ID" != "None" ]; then
+            echo "Disabling CloudFront distribution ${CF_DIST_ID}..."
+            ETAG=$(aws cloudfront get-distribution-config --id "$CF_DIST_ID" --query 'ETag' --output text)
+            aws cloudfront get-distribution-config --id "$CF_DIST_ID" --query 'DistributionConfig' > /tmp/cf-disable.json
+            python3 -c "
+import json
+with open('/tmp/cf-disable.json') as f: c = json.load(f)
+c['Enabled'] = False
+with open('/tmp/cf-disable.json', 'w') as f: json.dump(c, f)
+"
+            aws cloudfront update-distribution --id "$CF_DIST_ID" --if-match "$ETAG" \
+                --distribution-config file:///tmp/cf-disable.json --no-cli-pager > /dev/null 2>&1 || true
+            echo "Waiting for CloudFront to disable (this may take several minutes)..."
+            aws cloudfront wait distribution-deployed --id "$CF_DIST_ID" 2>/dev/null || true
+            NEW_ETAG=$(aws cloudfront get-distribution-config --id "$CF_DIST_ID" --query 'ETag' --output text)
+            aws cloudfront delete-distribution --id "$CF_DIST_ID" --if-match "$NEW_ETAG" 2>/dev/null || true
+            echo "CloudFront distribution deleted"
+            rm -f /tmp/cf-disable.json
+        fi
+    fi
+
+    echo "Deleting ECS service..."
+    aws ecs update-service --cluster "$CLUSTER_NAME" --service "$SERVICE_NAME" \
+        --desired-count 0 --region "$REGION" 2>/dev/null || true
+    aws ecs delete-service --cluster "$CLUSTER_NAME" --service "$SERVICE_NAME" \
+        --force --region "$REGION" 2>/dev/null || true
+
+    echo "Deregistering task definitions..."
+    TASK_DEFS=$(aws ecs list-task-definitions --family-prefix "$TASK_FAMILY" \
+        --region "$REGION" --query "taskDefinitionArns[]" --output text 2>/dev/null || true)
+    for td in $TASK_DEFS; do
+        aws ecs deregister-task-definition --task-definition "$td" --region "$REGION" 2>/dev/null || true
+    done
+
+    echo "Deleting web ALB..."
+    ALB_WEB_ARN=$(aws elbv2 describe-load-balancers --names "$ALB_WEB_NAME" \
+        --region "$REGION" --query "LoadBalancers[0].LoadBalancerArn" --output text 2>/dev/null || true)
+    if [ -n "$ALB_WEB_ARN" ] && [ "$ALB_WEB_ARN" != "None" ]; then
+        LISTENER_ARNS=$(aws elbv2 describe-listeners --load-balancer-arn "$ALB_WEB_ARN" \
+            --region "$REGION" --query "Listeners[*].ListenerArn" --output text 2>/dev/null || true)
+        for la in $LISTENER_ARNS; do
+            aws elbv2 delete-listener --listener-arn "$la" --region "$REGION" 2>/dev/null || true
+        done
+        aws elbv2 delete-load-balancer --load-balancer-arn "$ALB_WEB_ARN" --region "$REGION" 2>/dev/null || true
+        echo "Waiting for ALB deletion..."
+        sleep 10
+    fi
+
+    echo "Deleting ALB target group..."
+    TG_ARN=$(aws elbv2 describe-target-groups --names "$TG_NAME" \
+        --region "$REGION" --query "TargetGroups[0].TargetGroupArn" --output text 2>/dev/null || true)
+    if [ -n "$TG_ARN" ] && [ "$TG_ARN" != "None" ]; then
+        aws elbv2 delete-target-group --target-group-arn "$TG_ARN" --region "$REGION" 2>/dev/null || true
+    fi
+
+    echo "Deleting ECS security group..."
+    SG_WEB_ID=$(aws ec2 describe-security-groups --filters "Name=group-name,Values=${SG_WEB_NAME}" "Name=vpc-id,Values=${VPC_ID}" \
+        --region "$REGION" --query "SecurityGroups[0].GroupId" --output text 2>/dev/null || true)
+    if [ -n "$SG_WEB_ID" ] && [ "$SG_WEB_ID" != "None" ]; then
+        aws ec2 revoke-security-group-ingress \
+            --group-id "$SG_VPCE" --protocol tcp --port 443 \
+            --source-group "$SG_WEB_ID" --region "$REGION" 2>/dev/null || true
+        aws ec2 delete-security-group --group-id "$SG_WEB_ID" --region "$REGION" 2>/dev/null || true
+    fi
+
+    echo "Deleting ALB security group..."
+    SG_ALB_WEB_ID=$(aws ec2 describe-security-groups --filters "Name=group-name,Values=${SG_ALB_WEB_NAME}" "Name=vpc-id,Values=${VPC_ID}" \
+        --region "$REGION" --query "SecurityGroups[0].GroupId" --output text 2>/dev/null || true)
+    if [ -n "$SG_ALB_WEB_ID" ] && [ "$SG_ALB_WEB_ID" != "None" ]; then
+        aws ec2 delete-security-group --group-id "$SG_ALB_WEB_ID" --region "$REGION" 2>/dev/null || true
+    fi
+
+    echo "Deleting IAM role and policy..."
+    aws iam delete-role-policy --role-name "$TASK_ROLE_NAME" --policy-name "$TASK_ROLE_POLICY_NAME" 2>/dev/null || true
+    aws iam delete-role --role-name "$TASK_ROLE_NAME" 2>/dev/null || true
+
+    echo "Deleting CloudWatch log group..."
+    aws logs delete-log-group --log-group-name "$LOG_GROUP" --region "$REGION" 2>/dev/null || true
+
+    echo "Deleting ECR repository..."
+    aws ecr delete-repository --repository-name "$ECR_REPO_NAME" --force --region "$REGION" 2>/dev/null || true
+
+    echo ""
+    echo "=== Cleanup complete ==="
+    echo "Note: Cleanup order was CloudFront -> ECS -> ALB -> SGs -> IAM -> ECR"
+    exit 0
+fi
+
+# ---------- Step 1: ECR Repository ----------
+
+echo "=== Step 1: ECR Repository ==="
+aws ecr describe-repositories --repository-names "$ECR_REPO_NAME" --region "$REGION" 2>/dev/null \
+    || aws ecr create-repository --repository-name "$ECR_REPO_NAME" --region "$REGION" > /dev/null
+echo "ECR: ${ECR_URI}"
+
+# ---------- Step 2: Docker Build + Push ----------
+
+echo "=== Step 2: Docker Build + Push ==="
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ]; then
+    PLATFORM="linux/amd64"
+    CPU_ARCH="X86_64"
+else
+    PLATFORM="linux/arm64"
+    CPU_ARCH="ARM64"
+fi
+echo "Detected platform: ${PLATFORM} (${CPU_ARCH})"
+
+docker build --platform "$PLATFORM" --no-cache -t "${ECR_REPO_NAME}:${IMAGE_TAG}" "$SCRIPT_DIR"
+
+aws ecr get-login-password --region "$REGION" \
+    | docker login --username AWS --password-stdin "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+
+docker tag "${ECR_REPO_NAME}:${IMAGE_TAG}" "${ECR_URI}:${IMAGE_TAG}"
+docker push "${ECR_URI}:${IMAGE_TAG}"
+echo "Pushed: ${ECR_URI}:${IMAGE_TAG}"
+
+# ---------- Step 3: Security Groups ----------
+
+echo "=== Step 3: Security Groups (CloudFront prefix list) ==="
+
+# 3a: ALB Security Group — CloudFront managed prefix list ONLY
+# SECURITY: Never use 0.0.0.0/0. This prevents DyePack/Epoxy auto-mitigation.
+SG_ALB_WEB_ID=$(aws ec2 describe-security-groups \
+    --filters "Name=group-name,Values=${SG_ALB_WEB_NAME}" "Name=vpc-id,Values=${VPC_ID}" \
+    --region "$REGION" --query "SecurityGroups[0].GroupId" --output text 2>/dev/null || true)
+
+if [ -z "$SG_ALB_WEB_ID" ] || [ "$SG_ALB_WEB_ID" = "None" ]; then
+    SG_ALB_WEB_ID=$(aws ec2 create-security-group \
+        --group-name "$SG_ALB_WEB_NAME" \
+        --description "Allow HTTP from CloudFront only (prefix list ${CF_PREFIX_LIST})" \
+        --vpc-id "$VPC_ID" \
+        --region "$REGION" \
+        --query "GroupId" --output text)
+
+    aws ec2 authorize-security-group-ingress \
+        --group-id "$SG_ALB_WEB_ID" \
+        --ip-permissions "IpProtocol=tcp,FromPort=80,ToPort=80,PrefixListIds=[{PrefixListId=${CF_PREFIX_LIST},Description=CloudFront-managed-prefix-list}]" \
+        --region "$REGION" > /dev/null
+
+    # Remove default egress-all rule (least privilege)
+    aws ec2 revoke-security-group-egress \
+        --group-id "$SG_ALB_WEB_ID" \
+        --protocol all --cidr 0.0.0.0/0 \
+        --region "$REGION" > /dev/null
+    echo "ALB SG: ${SG_ALB_WEB_ID} (inbound: CloudFront prefix list only)"
+else
+    echo "ALB SG: ${SG_ALB_WEB_ID} (already exists)"
+fi
+
+# 3b: ECS Security Group (allow traffic from web ALB SG)
+SG_WEB_ID=$(aws ec2 describe-security-groups \
+    --filters "Name=group-name,Values=${SG_WEB_NAME}" "Name=vpc-id,Values=${VPC_ID}" \
+    --region "$REGION" --query "SecurityGroups[0].GroupId" --output text 2>/dev/null || true)
+
+if [ -z "$SG_WEB_ID" ] || [ "$SG_WEB_ID" = "None" ]; then
+    SG_WEB_ID=$(aws ec2 create-security-group \
+        --group-name "$SG_WEB_NAME" \
+        --description "Allow TCP 8080 from web ALB to deep-insight-web" \
+        --vpc-id "$VPC_ID" \
+        --region "$REGION" \
+        --query "GroupId" --output text)
+
+    aws ec2 authorize-security-group-ingress \
+        --group-id "$SG_WEB_ID" \
+        --protocol tcp --port 8080 \
+        --source-group "$SG_ALB_WEB_ID" \
+        --region "$REGION" > /dev/null
+fi
+
+# Ensure inbound rule from web ALB SG exists (handles reused SG)
+EXISTING_ECS_INGRESS=$(aws ec2 describe-security-group-rules \
+    --filters "Name=group-id,Values=${SG_WEB_ID}" \
+    --region "$REGION" \
+    --query "SecurityGroupRules[?IsEgress==\`false\` && IpProtocol==\`tcp\` && FromPort==\`8080\` && ToPort==\`8080\` && ReferencedGroupInfo.GroupId==\`${SG_ALB_WEB_ID}\`]" \
+    --output text 2>/dev/null || true)
+
+if [ -z "$EXISTING_ECS_INGRESS" ]; then
+    aws ec2 authorize-security-group-ingress \
+        --group-id "$SG_WEB_ID" \
+        --protocol tcp --port 8080 \
+        --source-group "$SG_ALB_WEB_ID" \
+        --region "$REGION" > /dev/null
+fi
+echo "ECS SG: ${SG_WEB_ID}"
+
+# 3c: ALB egress to ECS containers on port 8080
+EXISTING_ALB_EGRESS=$(aws ec2 describe-security-group-rules \
+    --filters "Name=group-id,Values=${SG_ALB_WEB_ID}" \
+    --region "$REGION" \
+    --query "SecurityGroupRules[?IsEgress==\`true\` && IpProtocol==\`tcp\` && FromPort==\`8080\` && ToPort==\`8080\` && ReferencedGroupInfo.GroupId==\`${SG_WEB_ID}\`]" \
+    --output text 2>/dev/null || true)
+
+if [ -z "$EXISTING_ALB_EGRESS" ]; then
+    aws ec2 authorize-security-group-egress \
+        --group-id "$SG_ALB_WEB_ID" \
+        --protocol tcp --port 8080 \
+        --source-group "$SG_WEB_ID" \
+        --region "$REGION" > /dev/null
+fi
+
+# 3d: Allow web SG to reach VPC endpoints
+EXISTING_VPCE_RULE=$(aws ec2 describe-security-group-rules \
+    --filters "Name=group-id,Values=${SG_VPCE}" \
+    --region "$REGION" \
+    --query "SecurityGroupRules[?IsEgress==\`false\` && IpProtocol==\`tcp\` && FromPort==\`443\` && ToPort==\`443\` && ReferencedGroupInfo.GroupId==\`${SG_WEB_ID}\`]" \
+    --output text 2>/dev/null || true)
+
+if [ -z "$EXISTING_VPCE_RULE" ]; then
+    aws ec2 authorize-security-group-ingress \
+        --group-id "$SG_VPCE" \
+        --protocol tcp --port 443 \
+        --source-group "$SG_WEB_ID" \
+        --region "$REGION" > /dev/null
+fi
+
+# ---------- Step 4: Internet-facing ALB + Target Group + Listener ----------
+
+echo "=== Step 4: Internet-facing ALB + Target Group + Listener ==="
+
+# 4a: Target Group
+TG_ARN=$(aws elbv2 describe-target-groups --names "$TG_NAME" \
+    --region "$REGION" --query "TargetGroups[0].TargetGroupArn" --output text 2>/dev/null || true)
+
+if [ -z "$TG_ARN" ] || [ "$TG_ARN" = "None" ]; then
+    TG_ARN=$(aws elbv2 create-target-group \
+        --name "$TG_NAME" \
+        --protocol HTTP --port 8080 \
+        --vpc-id "$VPC_ID" \
+        --target-type ip \
+        --health-check-path "/health" \
+        --health-check-interval-seconds 30 \
+        --healthy-threshold-count 2 \
+        --unhealthy-threshold-count 3 \
+        --region "$REGION" \
+        --query "TargetGroups[0].TargetGroupArn" --output text)
+fi
+echo "Target Group: ${TG_ARN}"
+
+# 4b: Internet-facing ALB
+ALB_WEB_ARN=$(aws elbv2 describe-load-balancers --names "$ALB_WEB_NAME" \
+    --region "$REGION" --query "LoadBalancers[0].LoadBalancerArn" --output text 2>/dev/null || true)
+
+if [ -z "$ALB_WEB_ARN" ] || [ "$ALB_WEB_ARN" = "None" ]; then
+    ALB_WEB_ARN=$(aws elbv2 create-load-balancer \
+        --name "$ALB_WEB_NAME" \
+        --scheme internet-facing \
+        --type application \
+        --subnets "$PUBLIC_SUBNET_1" "$PUBLIC_SUBNET_2" \
+        --security-groups "$SG_ALB_WEB_ID" \
+        --region "$REGION" \
+        --query "LoadBalancers[0].LoadBalancerArn" --output text)
+
+    echo "Waiting for ALB to become active..."
+    aws elbv2 wait load-balancer-available --load-balancer-arns "$ALB_WEB_ARN" --region "$REGION"
+fi
+
+ALB_WEB_DNS=$(aws elbv2 describe-load-balancers --load-balancer-arns "$ALB_WEB_ARN" \
+    --region "$REGION" --query "LoadBalancers[0].DNSName" --output text)
+echo "ALB: ${ALB_WEB_ARN}"
+echo "ALB DNS: ${ALB_WEB_DNS}"
+
+# Set ALB idle timeout to 3600s (1 hour) for long SSE streams
+aws elbv2 modify-load-balancer-attributes \
+    --load-balancer-arn "$ALB_WEB_ARN" \
+    --attributes Key=idle_timeout.timeout_seconds,Value=3600 \
+    --region "$REGION" > /dev/null
+echo "ALB idle timeout: 3600s"
+
+# 4c: Listener (port 80 -> target group)
+LISTENER_ARN=$(aws elbv2 describe-listeners --load-balancer-arn "$ALB_WEB_ARN" \
+    --region "$REGION" --query "Listeners[?Port==\`80\`].ListenerArn" --output text 2>/dev/null || true)
+
+if [ -z "$LISTENER_ARN" ] || [ "$LISTENER_ARN" = "None" ]; then
+    LISTENER_ARN=$(aws elbv2 create-listener \
+        --load-balancer-arn "$ALB_WEB_ARN" \
+        --protocol HTTP --port 80 \
+        --default-actions "[{\"Type\":\"forward\",\"TargetGroupArn\":\"${TG_ARN}\"}]" \
+        --region "$REGION" \
+        --query "Listeners[0].ListenerArn" --output text)
+fi
+echo "Listener: ${LISTENER_ARN}"
+
+# ---------- Step 5: IAM Task Role ----------
+
+echo "=== Step 5: IAM Task Role ==="
+TASK_ROLE_ARN_VALUE=$(aws iam get-role --role-name "$TASK_ROLE_NAME" \
+    --query "Role.Arn" --output text 2>/dev/null || true)
+
+if [ -z "$TASK_ROLE_ARN_VALUE" ] || [ "$TASK_ROLE_ARN_VALUE" = "None" ]; then
+    TRUST_POLICY='{
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+            "Action": "sts:AssumeRole"
+        }]
+    }'
+
+    TASK_ROLE_ARN_VALUE=$(aws iam create-role \
+        --role-name "$TASK_ROLE_NAME" \
+        --assume-role-policy-document "$TRUST_POLICY" \
+        --query "Role.Arn" --output text)
+
+    TASK_POLICY=$(cat <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "S3Upload",
+            "Effect": "Allow",
+            "Action": ["s3:PutObject"],
+            "Resource": "arn:aws:s3:::${S3_BUCKET}/uploads/*"
+        },
+        {
+            "Sid": "S3Feedback",
+            "Effect": "Allow",
+            "Action": ["s3:PutObject", "s3:GetObject"],
+            "Resource": "arn:aws:s3:::${S3_BUCKET}/deep-insight/feedback/*"
+        },
+        {
+            "Sid": "S3ArtifactsList",
+            "Effect": "Allow",
+            "Action": ["s3:ListBucket"],
+            "Resource": "arn:aws:s3:::${S3_BUCKET}",
+            "Condition": {
+                "StringLike": {
+                    "s3:prefix": "deep-insight/fargate_sessions/*/artifacts/*"
+                }
+            }
+        },
+        {
+            "Sid": "S3ArtifactsGet",
+            "Effect": "Allow",
+            "Action": ["s3:GetObject"],
+            "Resource": "arn:aws:s3:::${S3_BUCKET}/deep-insight/fargate_sessions/*/artifacts/*"
+        },
+        {
+            "Sid": "AgentCoreInvoke",
+            "Effect": "Allow",
+            "Action": ["bedrock-agentcore:InvokeAgentRuntime"],
+            "Resource": "*"
+        }
+    ]
+}
+POLICY
+)
+
+    aws iam put-role-policy \
+        --role-name "$TASK_ROLE_NAME" \
+        --policy-name "$TASK_ROLE_POLICY_NAME" \
+        --policy-document "$TASK_POLICY"
+fi
+echo "Task Role: ${TASK_ROLE_ARN_VALUE}"
+
+# ---------- Step 6: CloudWatch Log Group ----------
+
+echo "=== Step 6: CloudWatch Log Group ==="
+aws logs create-log-group --log-group-name "$LOG_GROUP" --region "$REGION" 2>/dev/null || true
+echo "Log Group: ${LOG_GROUP}"
+
+# ---------- Step 7: ECS Task Definition ----------
+
+echo "=== Step 7: ECS Task Definition (${CPU_ARCH}) ==="
+
+BASE_ENV='[
+    {"name": "RUNTIME_ARN", "value": "'"${RUNTIME_ARN_VALUE}"'"},
+    {"name": "AWS_REGION", "value": "'"${REGION}"'"},
+    {"name": "S3_BUCKET_NAME", "value": "'"${S3_BUCKET}"'"}
+]'
+
+CURRENT_ENV=$(aws ecs describe-task-definition --task-definition "$TASK_FAMILY" \
+    --region "$REGION" \
+    --query "taskDefinition.containerDefinitions[0].environment" --output json 2>/dev/null || echo "[]")
+
+MERGED_ENV=$(python3 -c "
+import json, sys
+base = json.loads(sys.argv[1])
+current = json.loads(sys.argv[2])
+base_names = {e['name'] for e in base}
+merged = list(base)
+for e in current:
+    if e['name'] not in base_names:
+        merged.append(e)
+json.dump(merged, sys.stdout)
+" "$BASE_ENV" "$CURRENT_ENV")
+
+TASK_DEF_FILE="/tmp/deep-insight-web-task-def.json"
+python3 -c "
+import json, sys
+env = json.loads(sys.argv[1])
+td = {
+    'family': '${TASK_FAMILY}',
+    'networkMode': 'awsvpc',
+    'requiresCompatibilities': ['FARGATE'],
+    'runtimePlatform': {
+        'cpuArchitecture': '${CPU_ARCH}',
+        'operatingSystemFamily': 'LINUX'
+    },
+    'cpu': '256',
+    'memory': '512',
+    'executionRoleArn': '${EXECUTION_ROLE_ARN}',
+    'taskRoleArn': '${TASK_ROLE_ARN_VALUE}',
+    'containerDefinitions': [{
+        'name': 'deep-insight-web',
+        'image': '${ECR_URI}:${IMAGE_TAG}',
+        'portMappings': [{'containerPort': 8080, 'protocol': 'tcp'}],
+        'environment': env,
+        'logConfiguration': {
+            'logDriver': 'awslogs',
+            'options': {
+                'awslogs-group': '${LOG_GROUP}',
+                'awslogs-region': '${REGION}',
+                'awslogs-stream-prefix': 'web'
+            }
+        },
+        'essential': True
+    }]
+}
+json.dump(td, sys.stdout)
+" "$MERGED_ENV" > "$TASK_DEF_FILE"
+
+TASK_DEF_ARN=$(aws ecs register-task-definition \
+    --cli-input-json "file://${TASK_DEF_FILE}" \
+    --region "$REGION" \
+    --query "taskDefinition.taskDefinitionArn" --output text)
+rm -f "$TASK_DEF_FILE"
+echo "Task Definition: ${TASK_DEF_ARN}"
+
+# ---------- Step 8: ECS Service ----------
+
+echo "=== Step 8: ECS Service ==="
+EXISTING_SERVICE=$(aws ecs describe-services --cluster "$CLUSTER_NAME" --services "$SERVICE_NAME" \
+    --region "$REGION" --query "services[?status=='ACTIVE'].serviceName" --output text 2>/dev/null || true)
+
+if [ -z "$EXISTING_SERVICE" ]; then
+    aws ecs create-service \
+        --cluster "$CLUSTER_NAME" \
+        --service-name "$SERVICE_NAME" \
+        --task-definition "$TASK_DEF_ARN" \
+        --desired-count 1 \
+        --launch-type FARGATE \
+        --network-configuration "awsvpcConfiguration={subnets=[${SUBNET_1},${SUBNET_2}],securityGroups=[${SG_WEB_ID}],assignPublicIp=DISABLED}" \
+        --load-balancers "targetGroupArn=${TG_ARN},containerName=deep-insight-web,containerPort=8080" \
+        --region "$REGION" > /dev/null
+    echo "Service created: ${SERVICE_NAME}"
+else
+    aws ecs update-service \
+        --cluster "$CLUSTER_NAME" \
+        --service "$SERVICE_NAME" \
+        --task-definition "$TASK_DEF_ARN" \
+        --force-new-deployment \
+        --region "$REGION" > /dev/null
+    echo "Service updated: ${SERVICE_NAME}"
+fi
+
+# ---------- Step 9: CloudFront Distribution ----------
+
+echo "=== Step 9: CloudFront Distribution ==="
+
+EXISTING_CF=$(aws cloudfront list-distributions \
+    --query "DistributionList.Items[?Origins.Items[?DomainName=='${ALB_WEB_DNS}']].{Id:Id,Domain:DomainName}" \
+    --output json 2>/dev/null || echo "[]")
+
+EXISTING_CF_ID=$(echo "$EXISTING_CF" | python3 -c "
+import json, sys
+items = json.load(sys.stdin)
+if items: print(items[0]['Id'])
+else: print('')
+" 2>/dev/null || true)
+
+if [ -z "$EXISTING_CF_ID" ]; then
+    CF_CONFIG_FILE="/tmp/cf-dist-config.json"
+    cat > "$CF_CONFIG_FILE" <<CFEOF
+{
+    "CallerReference": "deep-insight-web-$(date +%s)",
+    "Comment": "Deep Insight Web UI (CloudFront + ALB)",
+    "DefaultCacheBehavior": {
+        "TargetOriginId": "deep-insight-web-alb",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "AllowedMethods": {
+            "Quantity": 7,
+            "Items": ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"],
+            "CachedMethods": {"Quantity": 2, "Items": ["GET", "HEAD"]}
+        },
+        "ForwardedValues": {
+            "QueryString": true,
+            "Cookies": {"Forward": "all"},
+            "Headers": {"Quantity": 1, "Items": ["*"]}
+        },
+        "MinTTL": 0,
+        "DefaultTTL": 0,
+        "MaxTTL": 0,
+        "Compress": true
+    },
+    "Origins": {
+        "Quantity": 1,
+        "Items": [{
+            "Id": "deep-insight-web-alb",
+            "DomainName": "${ALB_WEB_DNS}",
+            "CustomOriginConfig": {
+                "HTTPPort": 80,
+                "HTTPSPort": 443,
+                "OriginProtocolPolicy": "http-only",
+                "OriginReadTimeout": 60,
+                "OriginKeepaliveTimeout": 60
+            }
+        }]
+    },
+    "Enabled": true,
+    "PriceClass": "PriceClass_200"
+}
+CFEOF
+
+    CF_RESULT=$(aws cloudfront create-distribution \
+        --distribution-config "file://${CF_CONFIG_FILE}" \
+        --query "Distribution.{Id:Id,Domain:DomainName}" \
+        --output json)
+    rm -f "$CF_CONFIG_FILE"
+
+    CF_DIST_ID=$(echo "$CF_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['Id'])")
+    CF_DOMAIN=$(echo "$CF_RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['Domain'])")
+    echo "CloudFront created: ${CF_DIST_ID}"
+    echo "Waiting for deployment (2-5 minutes)..."
+    aws cloudfront wait distribution-deployed --id "$CF_DIST_ID"
+else
+    CF_DIST_ID="$EXISTING_CF_ID"
+    CF_DOMAIN=$(echo "$EXISTING_CF" | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['Domain'])")
+    echo "CloudFront already exists: ${CF_DIST_ID}"
+fi
+
+echo "CloudFront Domain: ${CF_DOMAIN}"
+
+# ---------- Done ----------
+
+echo ""
+echo "============================================"
+echo "Deployment complete! (CloudFront mode)"
+echo "============================================"
+echo ""
+echo "URL: https://${CF_DOMAIN}"
+echo ""
+echo "CloudFront ID: ${CF_DIST_ID}"
+echo "ALB DNS:       ${ALB_WEB_DNS} (not directly accessible — CloudFront only)"
+echo "ALB SG:        ${SG_ALB_WEB_ID} (CloudFront prefix list: ${CF_PREFIX_LIST})"
+echo ""
+echo "Next steps:"
+echo "  1. Wait for ECS task to reach RUNNING:"
+echo "     aws ecs list-tasks --cluster ${CLUSTER_NAME} --service-name ${SERVICE_NAME} --region ${REGION}"
+echo ""
+echo "  2. (Optional) Add Cognito authentication:"
+echo "     bash add-cognito-auth.sh ${CF_DIST_ID}"
+echo ""
+echo "  3. Cleanup all resources:"
+echo "     bash deploy-cloudfront.sh cleanup"

--- a/deep-insight-web/deploy-cloudfront.sh
+++ b/deep-insight-web/deploy-cloudfront.sh
@@ -75,9 +75,19 @@ LOG_GROUP="/ecs/deep-insight-web"
 TASK_ROLE_NAME="deep-insight-web-task-role"
 TASK_ROLE_POLICY_NAME="deep-insight-web-task-policy"
 
-# CloudFront managed prefix list ID (same across all regions)
-# See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/LocationsOfEdgeServers.html
-CF_PREFIX_LIST="pl-82a045eb"
+# Look up CloudFront managed prefix list ID for the target region.
+# The prefix list name is always "com.amazonaws.global.cloudfront.origin-facing"
+# but the ID differs per region.
+CF_PREFIX_LIST=$(aws ec2 describe-managed-prefix-lists \
+    --filters "Name=prefix-list-name,Values=com.amazonaws.global.cloudfront.origin-facing" \
+    --region "$REGION" \
+    --query "PrefixLists[0].PrefixListId" --output text 2>/dev/null || true)
+
+if [ -z "$CF_PREFIX_LIST" ] || [ "$CF_PREFIX_LIST" = "None" ]; then
+    echo "ERROR: CloudFront managed prefix list not found in ${REGION}."
+    echo "Verify that the region supports CloudFront origin-facing prefix lists."
+    exit 1
+fi
 
 echo "============================================"
 echo "Deploy deep-insight-web (CloudFront mode)"


### PR DESCRIPTION
## 요약

`deep-insight-web/app.py`의 SSE 스트리밍에 keepalive를 추가하여, CloudFront 등 리버스 프록시 환경에서 idle timeout으로 연결이 끊어지는 문제를 수정합니다.

## 문제

- Coder agent가 Fargate container를 시작하는 동안(약 2분) SSE 이벤트가 전송되지 않음
- CloudFront 기본 Origin Read Timeout(60초) 초과로 연결이 끊어져 브라우저에 "network error" 발생
- CloudFront + Cognito 인증 환경 배포 시 재현됨

## 변경 내용

- `iter_lines()` blocking 호출을 별도 데몬 스레드(`_read_agentcore_events`)로 분리
- 메인 generator에서 30초(`SSE_KEEPALIVE_INTERVAL`)마다 SSE comment(`: keepalive`)를 전송
- SSE 스펙(W3C)에 의해 브라우저 EventSource는 comment를 무시하므로 기능에 영향 없음

## 호환성

| 배포 환경 | 영향 |
|-----------|------|
| CloudFront + ALB | 문제 해결 (keepalive가 60초 timeout 방지) |
| VPN CIDR + ALB (기존 deploy.sh) | 무해 (ALB idle timeout 3600초) |
| nginx/Traefik 등 다른 프록시 | 유익 (대부분 60~120초 timeout) |
| 프록시 없이 직접 접속 | 무해 |

## 참고: CloudFront + Cognito 배포 환경

현재 `deploy.sh`는 VPN CIDR 기반 ALB 직접 접속을 전제로 하고 있으나, CloudFront -> ALB 아키텍처로 배포할 경우 Origin Read Timeout 60초 제약이 있어 본 수정이 필수입니다. 향후 Web UI 배포 가이드에 CloudFront + Cognito 옵션 추가를 권장합니다.

## 테스트

- [x] CloudFront + Cognito + ALB 환경에서 full workflow 정상 동작 확인
- [x] Coder -> Validator -> Reporter 전체 pipeline 에러 없이 완료
- [x] SSE keepalive 30초 주기 전송 확인
- [x] 브라우저 EventSource 영향 없음 확인
- [x] 기존 VPN CIDR + ALB 환경 영향 없음 확인