### PR TITLE
Add json generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ We believe in the power of open collaboration. Deep Insight takes the excellent 
 | **Chloe(Younghwa) Kwak** | AWS Sr. Solutions Architect | [Email](mailto:younghwa@amazon.com) · [LinkedIn](https://www.linkedin.com/in/younghwakwak) · [GitHub](https://github.com/chloe-kwak) · [Hugging Face](https://huggingface.co/Chloe-yh) |
 | **Yoonseo Kim** | AWS Solutions Architect | [Email](mailto:ottlseo@amazon.com) · [LinkedIn](https://www.linkedin.com/in/ottlseo/) · [GitHub](https://github.com/ottlseo) |
 | **Jiyun Park** | AWS Solutions Architect | [Email](mailto:jiyunp@amazon.com) · [LinkedIn](https://www.linkedin.com/in/jiyunpark1128/) · [GitHub](https://github.com/glossyyoon) |
+| **Kyutae Park, Ph.D.** | AWS AI/ML Specialist SA | [Email](mailto:kyutae@amazon.com) · [LinkedIn](https://www.linkedin.com/in/ren-ai-ssance/) · [GitHub](https://github.com/ren-ai-ssance)
 | **Dongjin Jang, Ph.D.** | Previous AWS Sr. AI/ML Specialist SA | [Email](mailto:dongjinj@amazon.com) · [LinkedIn](https://www.linkedin.com/in/dongjin-jang-kr/) · [GitHub](https://github.com/dongjin-ml) · [Hugging Face](https://huggingface.co/Dongjin-kr) 
 
 ---

--- a/deep-insight-web/app.py
+++ b/deep-insight-web/app.py
@@ -24,8 +24,8 @@ from urllib.parse import quote
 from ops.job_tracker import track_job_start, track_job_link, track_job_failure
 from ops.admin_router import admin_router
 
-from fastapi import FastAPI, File, UploadFile
-from fastapi.responses import FileResponse, HTMLResponse, Response, StreamingResponse
+from fastapi import FastAPI, File, Form, UploadFile
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Response, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 
@@ -132,6 +132,107 @@ def get_sample_report(filename: str):
         return {"success": False, "error": "Invalid path"}
 
     return FileResponse(file_path, filename=filename)
+
+
+# ---------- Feature 1.5: Auto-generate column definitions ----------
+
+
+def _parse_csv_preview(raw_bytes: bytes, max_rows: int = 5) -> tuple[list[str], list[list[str]]]:
+    """Read CSV header and up to max_rows sample rows from raw bytes."""
+    import csv
+    import io
+
+    text = raw_bytes.decode("utf-8-sig", errors="replace")
+    reader = csv.reader(io.StringIO(text))
+    headers = next(reader, [])
+    rows = []
+    for row in reader:
+        rows.append(row)
+        if len(rows) >= max_rows:
+            break
+    return headers, rows
+
+
+@app.post("/generate-column-definitions")
+async def generate_column_definitions(
+    data_file: UploadFile = File(...),
+    lang: str = Form("ko"),
+):
+    """Read CSV header + sample rows and call Bedrock Claude to generate column_definitions.json."""
+    try:
+        raw = await data_file.read()
+        headers, sample_rows = _parse_csv_preview(raw)
+
+        if not headers:
+            return JSONResponse(
+                status_code=400,
+                content={"success": False, "error": "Could not parse CSV headers"},
+            )
+
+        # Build a preview table for the LLM
+        preview_lines = [",".join(headers)]
+        for row in sample_rows:
+            preview_lines.append(",".join(row))
+        preview_text = "\n".join(preview_lines)
+
+        lang_instruction = (
+            "Write column_desc in Korean." if lang == "ko"
+            else "Write column_desc in English."
+        )
+
+        prompt = f"""Analyze the following CSV data (header + sample rows) and generate a column_definitions JSON array.
+
+For each column, produce an object with:
+- "column_name": the exact column header from the CSV
+- "column_desc": a clear, concise description of what the column represents, including data type, unit, or format if apparent from the sample data.
+
+{lang_instruction}
+
+Return ONLY a valid JSON array, no markdown fences, no explanation.
+
+CSV data:
+{preview_text}"""
+
+        bedrock = boto3.client("bedrock-runtime", region_name=AWS_REGION)
+        body = json.dumps({
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 2048,
+            "messages": [{"role": "user", "content": prompt}],
+        })
+
+        response = bedrock.invoke_model(
+            modelId="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            contentType="application/json",
+            accept="application/json",
+            body=body,
+        )
+
+        result = json.loads(response["body"].read())
+        text_content = result["content"][0]["text"].strip()
+
+        # Strip markdown code fences if present (```json ... ```)
+        if text_content.startswith("```"):
+            lines = text_content.split("\n")
+            # Remove first line (```json) and last line (```)
+            lines = [l for l in lines if not l.strip().startswith("```")]
+            text_content = "\n".join(lines).strip()
+
+        # Parse the JSON to validate it
+        column_definitions = json.loads(text_content)
+
+        return {"success": True, "column_definitions": column_definitions}
+
+    except json.JSONDecodeError:
+        return JSONResponse(
+            status_code=500,
+            content={"success": False, "error": "LLM returned invalid JSON. Please try again."},
+        )
+    except Exception as e:
+        logger.error(f"Column definition generation failed: {e}")
+        return JSONResponse(
+            status_code=500,
+            content={"success": False, "error": str(e)},
+        )
 
 
 # ---------- Feature 2: Static page serving ----------

--- a/deep-insight-web/app.py
+++ b/deep-insight-web/app.py
@@ -42,6 +42,7 @@ logger = logging.getLogger(__name__)
 RUNTIME_ARN = os.environ.get("RUNTIME_ARN", "")
 AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
 S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME", "")
+WEB_UTILITY_MODEL_ID = os.environ.get("WEB_UTILITY_MODEL_ID", "global.anthropic.claude-haiku-4-5-20251001-v1:0")
 
 STATIC_DIR = Path(__file__).resolve().parent / "static"
 SAMPLE_DATA_DIR = Path(__file__).resolve().parent / "sample_data"
@@ -201,7 +202,7 @@ CSV data:
         })
 
         response = bedrock.invoke_model(
-            modelId="us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            modelId=WEB_UTILITY_MODEL_ID,
             contentType="application/json",
             accept="application/json",
             body=body,

--- a/deep-insight-web/static/css/styles.css
+++ b/deep-insight-web/static/css/styles.css
@@ -387,6 +387,220 @@ label .req { color: var(--red); margin-left: 0.2rem; }
 .drop-zone-sm .drop-zone-text { font-size: 0.85rem; }
 .drop-zone-sm .drop-zone-hint { font-size: 0.75rem; }
 
+/* ===== Auto-generate Column Definitions ===== */
+.autogen-divider {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    margin: 0.8rem 0;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+}
+.autogen-divider::before,
+.autogen-divider::after {
+    content: '';
+    flex: 1;
+    border-top: 1px solid var(--border);
+}
+/* Primary auto-generate button (prominent CTA) */
+.btn-autogen-primary {
+    width: 100%;
+    background: linear-gradient(135deg, rgba(74, 124, 255, 0.18) 0%, rgba(74, 124, 255, 0.10) 100%);
+    color: #fff;
+    border: 1.5px solid rgba(74, 124, 255, 0.5);
+    border-radius: var(--radius-sm);
+    padding: 1rem 1rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.25s;
+    box-shadow: 0 2px 8px rgba(74, 124, 255, 0.12);
+    position: relative;
+    overflow: hidden;
+}
+.btn-autogen-primary::after {
+    content: '✨';
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 1rem;
+    opacity: 0.6;
+    transition: all 0.25s;
+}
+.btn-autogen-primary:hover {
+    background: linear-gradient(135deg, rgba(74, 124, 255, 0.3) 0%, rgba(74, 124, 255, 0.18) 100%);
+    border-color: var(--accent);
+    box-shadow: 0 4px 20px rgba(74, 124, 255, 0.25);
+    transform: translateY(-1px);
+}
+.btn-autogen-primary:hover::after {
+    opacity: 1;
+}
+.btn-autogen-primary:active {
+    transform: translateY(0);
+    box-shadow: 0 1px 4px rgba(74, 124, 255, 0.15);
+}
+.btn-autogen-primary:disabled {
+    color: var(--text-muted);
+    border-color: var(--border);
+    background: var(--bg-elevated);
+    box-shadow: none;
+    cursor: wait;
+    transform: none;
+}
+.btn-autogen-primary:disabled::after { display: none; }
+.coldef-autogen-desc {
+    margin-top: 0.4rem;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    text-align: center;
+    line-height: 1.4;
+}
+/* Secondary drop zone (less prominent when autogen is primary) */
+.drop-zone-secondary {
+    border-style: dashed;
+    opacity: 0.8;
+    padding: 0.9rem;
+}
+.drop-zone-secondary .drop-zone-icon { font-size: 1.2rem; margin-bottom: 0.2rem; }
+.drop-zone-secondary .drop-zone-text { font-size: 0.82rem; }
+.drop-zone-secondary .drop-zone-hint { font-size: 0.72rem; }
+.drop-zone-secondary:hover { opacity: 1; }
+#coldef-autogen-status {
+    margin-top: 0.5rem;
+    font-size: 0.82rem;
+    color: var(--text-muted);
+}
+.coldef-review-panel {
+    margin-top: 0.8rem;
+    background: var(--bg-surface);
+    border: 1px solid rgba(52, 211, 153, 0.25);
+    border-radius: var(--radius-sm);
+    padding: 1rem;
+    animation: slideUp 0.3s ease-out;
+}
+.coldef-review-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.7rem;
+}
+.coldef-review-title {
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--green);
+}
+.coldef-review-actions-top {
+    display: flex;
+    gap: 0.4rem;
+}
+.btn-sm {
+    padding: 0.4rem 0.8rem;
+    font-size: 0.8rem;
+    border-radius: var(--radius-xs);
+}
+.btn-outline {
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-hover);
+    cursor: pointer;
+    transition: all 0.2s;
+    font-weight: 500;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+.btn-outline:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+    background: var(--accent-glow);
+    box-shadow: 0 2px 6px rgba(74, 124, 255, 0.15);
+    transform: translateY(-1px);
+}
+.btn-outline:active {
+    transform: translateY(0);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+.coldef-review-preview {
+    background: var(--bg-deep);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xs);
+    padding: 0.8rem;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+    max-height: 260px;
+    overflow-y: auto;
+    line-height: 1.5;
+}
+.coldef-review-editor {
+    width: 100%;
+    background: var(--bg-deep);
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-xs);
+    padding: 0.8rem;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    color: var(--text-primary);
+    resize: vertical;
+    line-height: 1.5;
+    box-shadow: 0 0 0 3px var(--accent-glow);
+}
+.coldef-review-editor:focus { outline: none; }
+.coldef-review-table {
+    max-height: 280px;
+    overflow-y: auto;
+    border-radius: var(--radius-xs);
+    border: 1px solid var(--border);
+}
+.coldef-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.82rem;
+}
+.coldef-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+}
+.coldef-table th {
+    background: var(--bg-elevated);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.55rem 0.8rem;
+    text-align: left;
+    border-bottom: 1px solid var(--border);
+}
+.coldef-table td {
+    padding: 0.5rem 0.8rem;
+    border-bottom: 1px solid var(--border);
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+.coldef-table tr:last-child td { border-bottom: none; }
+.coldef-table tr:hover td { background: rgba(74, 124, 255, 0.04); }
+.coldef-table-name {
+    color: var(--accent) !important;
+    font-family: var(--font-mono);
+    font-weight: 500;
+    white-space: nowrap;
+}
+.btn-view-active {
+    border-color: var(--accent) !important;
+    color: var(--accent) !important;
+    background: rgba(74, 124, 255, 0.15) !important;
+    box-shadow: 0 1px 4px rgba(74, 124, 255, 0.2) !important;
+}
+.coldef-review-actions {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 0.7rem;
+}
+
 /* ===== Buttons ===== */
 .btn {
     font-family: var(--font-display);

--- a/deep-insight-web/static/index.html
+++ b/deep-insight-web/static/index.html
@@ -130,7 +130,17 @@
                 </div>
                 <div class="field">
                     <label for="col-def"><span data-i18n="upload_coldef_label">컬럼 정의</span> <span class="tag-recommended" data-i18n="upload_coldef_tag">권장</span></label>
-                    <div class="drop-zone drop-zone-sm" id="drop-zone-coldef">
+                    <div id="selected-coldef" class="hidden"></div>
+                    <!-- Auto-generate (Primary) — shown when data file selected, no coldef -->
+                    <div id="coldef-autogen-area" class="hidden">
+                        <button type="button" id="coldef-autogen-btn" class="btn btn-autogen-primary" data-i18n="coldef_autogen_btn">🤖 컬럼 정의 자동 생성</button>
+                        <div class="coldef-autogen-desc" data-i18n="coldef_autogen_desc">업로드한 데이터 파일을 기반으로 AI가 컬럼 정의를 자동 생성합니다</div>
+                        <div id="coldef-autogen-status" class="hidden"></div>
+                    </div>
+                    <!-- "or" divider — shown when autogen area is visible -->
+                    <div id="coldef-manual-divider" class="autogen-divider hidden"><span data-i18n="coldef_or">또는</span></div>
+                    <!-- Manual upload (Secondary) -->
+                    <div class="drop-zone drop-zone-sm drop-zone-secondary" id="drop-zone-coldef">
                         <input type="file" id="col-def" accept=".json">
                         <div class="drop-zone-icon">📄</div>
                         <div class="drop-zone-text">
@@ -138,7 +148,24 @@
                         </div>
                         <div class="drop-zone-hint" data-i18n="upload_coldef_hint">컬럼의 도메인 고유 의미와 수식을 정의하는 JSON 파일</div>
                     </div>
-                    <div id="selected-coldef" class="hidden"></div>
+                    <!-- Review panel for generated column definitions -->
+                    <div id="coldef-review-panel" class="hidden coldef-review-panel">
+                        <div class="coldef-review-header">
+                            <span class="coldef-review-title" data-i18n="coldef_review_title">생성된 컬럼 정의</span>
+                            <div class="coldef-review-actions-top">
+                                <button type="button" id="coldef-view-toggle-btn" class="btn btn-sm btn-outline btn-view-active" data-i18n="coldef_view_table">📊 테이블</button>
+                                <button type="button" id="coldef-regen-btn" class="btn btn-sm btn-outline" data-i18n="coldef_regen_btn">🔄 재생성</button>
+                                <button type="button" id="coldef-edit-toggle-btn" class="btn btn-sm btn-outline" data-i18n="coldef_edit_btn">✏️ 직접 수정</button>
+                            </div>
+                        </div>
+                        <div id="coldef-review-table" class="coldef-review-table"></div>
+                        <textarea id="coldef-review-editor" class="coldef-review-editor hidden" rows="12"></textarea>
+                        <pre id="coldef-review-preview" class="coldef-review-preview hidden"></pre>
+                        <div class="coldef-review-actions">
+                            <button type="button" id="coldef-confirm-btn" class="btn btn-green" data-i18n="coldef_confirm_btn">✓ 이 정의 사용</button>
+                            <button type="button" id="coldef-cancel-btn" class="btn btn-sm btn-outline" data-i18n="coldef_cancel_btn">취소</button>
+                        </div>
+                    </div>
                 </div>
                 <button type="submit" id="upload-btn" class="btn btn-primary" data-i18n="upload_btn">업로드</button>
             </form>

--- a/deep-insight-web/static/js/i18n.js
+++ b/deep-insight-web/static/js/i18n.js
@@ -75,6 +75,23 @@ const translations = {
         status_uploading: "업로드 중...",
         status_upload_complete: "✓ 업로드 완료. Upload ID: ",
         status_upload_failed: "업로드 실패: ",
+        coldef_or: "또는",
+        coldef_autogen_btn: "🤖 컬럼 정의 자동 생성",
+        coldef_autogen_desc: "업로드한 데이터 파일을 기반으로 AI가 컬럼 정의를 자동 생성합니다",
+        coldef_generating: "⏳ 생성 중...",
+        coldef_generating_hint: "AI가 컬럼 정의를 분석하고 있습니다...",
+        coldef_gen_failed: "생성 실패: ",
+        coldef_review_title: "생성된 컬럼 정의",
+        coldef_regen_btn: "🔄 재생성",
+        coldef_edit_btn: "✏️ 직접 수정",
+        coldef_preview_btn: "👁 미리보기",
+        coldef_confirm_btn: "✓ 이 정의 사용",
+        coldef_cancel_btn: "취소",
+        coldef_auto_generated: "자동 생성됨: column_definitions.json",
+        coldef_view_table: "📊 테이블",
+        coldef_view_json: "{ } JSON",
+        coldef_table_col_name: "컬럼명",
+        coldef_table_col_desc: "설명",
     },
     en: {
         hero_tagline_prefix: "A platform for building diverse agent applications including reporting — ",
@@ -151,6 +168,23 @@ const translations = {
         status_uploading: "Uploading...",
         status_upload_complete: "✓ Upload complete. Upload ID: ",
         status_upload_failed: "Upload failed: ",
+        coldef_or: "or",
+        coldef_autogen_btn: "🤖 Auto-generate Column Definitions",
+        coldef_autogen_desc: "AI generates column definitions based on your uploaded data file",
+        coldef_generating: "⏳ Generating...",
+        coldef_generating_hint: "AI is analyzing your columns...",
+        coldef_gen_failed: "Generation failed: ",
+        coldef_review_title: "Generated Column Definitions",
+        coldef_regen_btn: "🔄 Regenerate",
+        coldef_edit_btn: "✏️ Edit",
+        coldef_preview_btn: "👁 Preview",
+        coldef_confirm_btn: "✓ Use These Definitions",
+        coldef_cancel_btn: "Cancel",
+        coldef_auto_generated: "Auto-generated: column_definitions.json",
+        coldef_view_table: "📊 Table",
+        coldef_view_json: "{ } JSON",
+        coldef_table_col_name: "Column",
+        coldef_table_col_desc: "Description",
     }
 };
 
@@ -186,6 +220,9 @@ function applyLanguage() {
     renderPromptExamples();
     renderSampleDataLinks();
     renderSampleReportsLinks();
+    if (typeof refreshSelectedFileDisplays === "function") {
+        refreshSelectedFileDisplays();
+    }
 }
 
 // ==================== Guide ====================

--- a/deep-insight-web/static/js/upload.js
+++ b/deep-insight-web/static/js/upload.js
@@ -39,6 +39,9 @@ function initUpload() {
         }
     });
 
+    // Auto-generate column definitions
+    initColdefAutogen();
+
     // Upload form submission
     uploadForm.addEventListener("submit", async (e) => {
         e.preventDefault();
@@ -48,7 +51,13 @@ function initUpload() {
         const formData = new FormData();
         formData.append("data_file", dataFile);
         const colDef = document.getElementById("col-def").files[0];
-        if (colDef) formData.append("column_definitions", colDef);
+        if (colDef) {
+            formData.append("column_definitions", colDef);
+        } else if (_generatedColdefJson) {
+            // Use auto-generated column definitions
+            const blob = new Blob([JSON.stringify(_generatedColdefJson, null, 2)], { type: "application/json" });
+            formData.append("column_definitions", blob, "column_definitions.json");
+        }
 
         uploadBtn.disabled = true;
         statusDiv.textContent = translations[currentLang].status_uploading;
@@ -96,6 +105,8 @@ function showSelectedFile(name) {
     selectedFileDiv.appendChild(span);
     selectedFileDiv.classList.remove("hidden");
     dropZone.classList.add("hidden");
+    // Show auto-generate option if CSV-like file and no coldef selected
+    updateAutogenVisibility();
 }
 
 function clearFile() {
@@ -106,6 +117,7 @@ function clearFile() {
     selectedFileDiv.textContent = "";
     selectedFileDiv.classList.add("hidden");
     dropZone.classList.remove("hidden");
+    hideAutogenArea();
 }
 
 function showSelectedColdef(name) {
@@ -125,6 +137,7 @@ function showSelectedColdef(name) {
     selectedDiv.appendChild(span);
     selectedDiv.classList.remove("hidden");
     coldefZone.classList.add("hidden");
+    hideAutogenArea();
 }
 
 function clearColdef() {
@@ -135,6 +148,287 @@ function clearColdef() {
     selectedDiv.textContent = "";
     selectedDiv.classList.add("hidden");
     coldefZone.classList.remove("hidden");
+    _generatedColdefJson = null;
+    updateAutogenVisibility();
+}
+
+// ==================== Auto-generate Column Definitions ====================
+let _generatedColdefJson = null;
+let _isEditing = false;
+let _viewMode = "table"; // "table" or "json"
+
+function updateAutogenVisibility() {
+    const area = document.getElementById("coldef-autogen-area");
+    const divider = document.getElementById("coldef-manual-divider");
+    const dataFile = document.getElementById("data-file").files[0];
+    const colDef = document.getElementById("col-def").files[0];
+    const reviewPanel = document.getElementById("coldef-review-panel");
+    const isReviewing = reviewPanel && !reviewPanel.classList.contains("hidden");
+
+    if (dataFile && !colDef && !isReviewing && !_generatedColdefJson) {
+        area.classList.remove("hidden");
+        divider.classList.remove("hidden");
+    } else {
+        area.classList.add("hidden");
+        divider.classList.add("hidden");
+    }
+}
+
+function hideAutogenArea() {
+    document.getElementById("coldef-autogen-area").classList.add("hidden");
+    document.getElementById("coldef-manual-divider").classList.add("hidden");
+    document.getElementById("coldef-review-panel").classList.add("hidden");
+    document.getElementById("coldef-autogen-status").classList.add("hidden");
+    _generatedColdefJson = null;
+    _isEditing = false;
+}
+
+function initColdefAutogen() {
+    const autogenBtn = document.getElementById("coldef-autogen-btn");
+    const regenBtn = document.getElementById("coldef-regen-btn");
+    const editToggleBtn = document.getElementById("coldef-edit-toggle-btn");
+    const confirmBtn = document.getElementById("coldef-confirm-btn");
+    const cancelBtn = document.getElementById("coldef-cancel-btn");
+
+    const viewToggleBtn = document.getElementById("coldef-view-toggle-btn");
+
+    autogenBtn.addEventListener("click", () => generateColdef());
+    regenBtn.addEventListener("click", () => generateColdef());
+    viewToggleBtn.addEventListener("click", toggleColdefView);
+    editToggleBtn.addEventListener("click", toggleColdefEdit);
+    confirmBtn.addEventListener("click", confirmColdef);
+    cancelBtn.addEventListener("click", cancelColdef);
+}
+
+async function generateColdef() {
+    const dataFile = document.getElementById("data-file").files[0];
+    if (!dataFile) return;
+
+    const t = translations[currentLang];
+    const autogenBtn = document.getElementById("coldef-autogen-btn");
+    const statusDiv = document.getElementById("coldef-autogen-status");
+    const reviewPanel = document.getElementById("coldef-review-panel");
+
+    // Show loading
+    autogenBtn.disabled = true;
+    autogenBtn.textContent = t.coldef_generating || "⏳ 생성 중...";
+    statusDiv.classList.remove("hidden");
+    statusDiv.textContent = t.coldef_generating_hint || "AI가 컬럼 정의를 분석하고 있습니다...";
+    statusDiv.style.color = "var(--text-muted)";
+    reviewPanel.classList.add("hidden");
+
+    try {
+        const formData = new FormData();
+        formData.append("data_file", dataFile);
+        formData.append("lang", currentLang);
+
+        const res = await fetch("/generate-column-definitions", { method: "POST", body: formData });
+        const data = await res.json();
+
+        if (data.success) {
+            _generatedColdefJson = data.column_definitions;
+            showColdefReview(data.column_definitions);
+            statusDiv.classList.add("hidden");
+            document.getElementById("coldef-autogen-area").classList.add("hidden");
+            document.getElementById("coldef-manual-divider").classList.add("hidden");
+        } else {
+            statusDiv.textContent = (t.coldef_gen_failed || "생성 실패: ") + (data.error || "Unknown error");
+            statusDiv.style.color = "var(--red)";
+        }
+    } catch (err) {
+        statusDiv.textContent = (t.coldef_gen_failed || "생성 실패: ") + err.message;
+        statusDiv.style.color = "var(--red)";
+    } finally {
+        autogenBtn.disabled = false;
+        autogenBtn.textContent = t.coldef_autogen_btn || "🤖 컬럼 정의 자동 생성";
+    }
+}
+
+function showColdefReview(coldefArray) {
+    const preview = document.getElementById("coldef-review-preview");
+    const tableDiv = document.getElementById("coldef-review-table");
+    const editor = document.getElementById("coldef-review-editor");
+    const panel = document.getElementById("coldef-review-panel");
+
+    const jsonStr = JSON.stringify(coldefArray, null, 2);
+    preview.textContent = jsonStr;
+    editor.value = jsonStr;
+    renderColdefTable(coldefArray);
+
+    _isEditing = false;
+    _viewMode = "table";
+    tableDiv.classList.remove("hidden");
+    preview.classList.add("hidden");
+    editor.classList.add("hidden");
+    updateViewToggleBtn();
+    panel.classList.remove("hidden");
+    panel.scrollIntoView({ behavior: "smooth", block: "center" });
+}
+
+function renderColdefTable(coldefArray) {
+    const t = translations[currentLang];
+    const tableDiv = document.getElementById("coldef-review-table");
+    const headerName = t.coldef_table_col_name || "컬럼명";
+    const headerDesc = t.coldef_table_col_desc || "설명";
+
+    let html = `<table class="coldef-table"><thead><tr><th>${headerName}</th><th>${headerDesc}</th></tr></thead><tbody>`;
+    for (const col of coldefArray) {
+        const name = (col.column_name || "").replace(/</g, "&lt;");
+        const desc = (col.column_desc || "").replace(/</g, "&lt;");
+        html += `<tr><td class="coldef-table-name">${name}</td><td>${desc}</td></tr>`;
+    }
+    html += "</tbody></table>";
+    tableDiv.innerHTML = html;
+}
+
+function toggleColdefView() {
+    if (_isEditing) return; // Don't toggle while editing
+
+    const preview = document.getElementById("coldef-review-preview");
+    const tableDiv = document.getElementById("coldef-review-table");
+
+    if (_viewMode === "table") {
+        _viewMode = "json";
+        tableDiv.classList.add("hidden");
+        preview.classList.remove("hidden");
+    } else {
+        _viewMode = "table";
+        preview.classList.add("hidden");
+        tableDiv.classList.remove("hidden");
+    }
+    updateViewToggleBtn();
+}
+
+function updateViewToggleBtn() {
+    const btn = document.getElementById("coldef-view-toggle-btn");
+    const t = translations[currentLang];
+    if (_viewMode === "table") {
+        btn.textContent = t.coldef_view_json || "{ } JSON";
+        btn.classList.remove("btn-view-active");
+    } else {
+        btn.textContent = t.coldef_view_table || "📊 테이블";
+        btn.classList.add("btn-view-active");
+    }
+}
+
+function toggleColdefEdit() {
+    const preview = document.getElementById("coldef-review-preview");
+    const editor = document.getElementById("coldef-review-editor");
+    const t = translations[currentLang];
+    const btn = document.getElementById("coldef-edit-toggle-btn");
+
+    _isEditing = !_isEditing;
+    if (_isEditing) {
+        editor.value = preview.textContent;
+        preview.classList.add("hidden");
+        document.getElementById("coldef-review-table").classList.add("hidden");
+        editor.classList.remove("hidden");
+        editor.focus();
+        btn.textContent = t.coldef_preview_btn || "👁 미리보기";
+    } else {
+        // Validate JSON on switch back
+        try {
+            const parsed = JSON.parse(editor.value);
+            preview.textContent = JSON.stringify(parsed, null, 2);
+            _generatedColdefJson = parsed;
+            renderColdefTable(parsed);
+        } catch {
+            // Keep editor open if invalid
+            _isEditing = true;
+            editor.style.borderColor = "var(--red)";
+            setTimeout(() => { editor.style.borderColor = ""; }, 1500);
+            return;
+        }
+        editor.classList.add("hidden");
+        // Restore the active view mode
+        if (_viewMode === "table") {
+            document.getElementById("coldef-review-table").classList.remove("hidden");
+            preview.classList.add("hidden");
+        } else {
+            preview.classList.remove("hidden");
+            document.getElementById("coldef-review-table").classList.add("hidden");
+        }
+        btn.textContent = t.coldef_edit_btn || "✏️ 직접 수정";
+    }
+}
+
+function confirmColdef() {
+    const t = translations[currentLang];
+
+    // If editing, save current editor content
+    if (_isEditing) {
+        try {
+            _generatedColdefJson = JSON.parse(document.getElementById("coldef-review-editor").value);
+        } catch {
+            return;  // Invalid JSON, don't confirm
+        }
+    }
+
+    // Show as selected coldef
+    const selectedDiv = document.getElementById("selected-coldef");
+    const coldefZone = document.getElementById("drop-zone-coldef");
+    selectedDiv.textContent = "";
+    const span = document.createElement("span");
+    span.className = "file-selected";
+    span.textContent = "🤖 " + (t.coldef_auto_generated || "자동 생성됨: column_definitions.json") + " ";
+    const removeBtn = document.createElement("span");
+    removeBtn.className = "remove-file";
+    removeBtn.title = "Remove";
+    removeBtn.textContent = "✕";
+    removeBtn.addEventListener("click", clearColdef);
+    span.appendChild(removeBtn);
+    selectedDiv.appendChild(span);
+    selectedDiv.classList.remove("hidden");
+    coldefZone.classList.add("hidden");
+
+    // Hide review panel, autogen area, and divider
+    document.getElementById("coldef-review-panel").classList.add("hidden");
+    document.getElementById("coldef-autogen-area").classList.add("hidden");
+    document.getElementById("coldef-manual-divider").classList.add("hidden");
+    _isEditing = false;
+}
+
+function cancelColdef() {
+    document.getElementById("coldef-review-panel").classList.add("hidden");
+    _generatedColdefJson = null;
+    _isEditing = false;
+    updateAutogenVisibility();
+}
+
+// ==================== Refresh on language change ====================
+function refreshSelectedFileDisplays() {
+    const dataFile = document.getElementById("data-file").files[0];
+    const selectedFileDiv = document.getElementById("selected-file");
+    if (dataFile && !selectedFileDiv.classList.contains("hidden")) {
+        showSelectedFile(dataFile.name);
+    }
+
+    const colDef = document.getElementById("col-def").files[0];
+    const selectedColdef = document.getElementById("selected-coldef");
+    if (colDef && !selectedColdef.classList.contains("hidden")) {
+        showSelectedColdef(colDef.name);
+    } else if (_generatedColdefJson && !selectedColdef.classList.contains("hidden")) {
+        // Re-render auto-generated badge with updated language
+        const t = translations[currentLang];
+        selectedColdef.textContent = "";
+        const span = document.createElement("span");
+        span.className = "file-selected";
+        span.textContent = "🤖 " + (t.coldef_auto_generated || "자동 생성됨: column_definitions.json") + " ";
+        const removeBtn = document.createElement("span");
+        removeBtn.className = "remove-file";
+        removeBtn.title = "Remove";
+        removeBtn.textContent = "✕";
+        removeBtn.addEventListener("click", clearColdef);
+        span.appendChild(removeBtn);
+        selectedColdef.appendChild(span);
+    }
+
+    // Refresh review table headers if visible
+    const reviewPanel = document.getElementById("coldef-review-panel");
+    if (_generatedColdefJson && reviewPanel && !reviewPanel.classList.contains("hidden")) {
+        renderColdefTable(_generatedColdefJson);
+        updateViewToggleBtn();
+    }
 }
 
 // ==================== Sample Data ====================

--- a/deep-insight-web/static/js/upload.js
+++ b/deep-insight-web/static/js/upload.js
@@ -211,9 +211,9 @@ async function generateColdef() {
 
     // Show loading
     autogenBtn.disabled = true;
-    autogenBtn.textContent = t.coldef_generating || "⏳ 생성 중...";
+    autogenBtn.textContent = t.coldef_generating || "⏳ Generating...";
     statusDiv.classList.remove("hidden");
-    statusDiv.textContent = t.coldef_generating_hint || "AI가 컬럼 정의를 분석하고 있습니다...";
+    statusDiv.textContent = t.coldef_generating_hint || "AI is analyzing your columns...";
     statusDiv.style.color = "var(--text-muted)";
     reviewPanel.classList.add("hidden");
 
@@ -232,15 +232,15 @@ async function generateColdef() {
             document.getElementById("coldef-autogen-area").classList.add("hidden");
             document.getElementById("coldef-manual-divider").classList.add("hidden");
         } else {
-            statusDiv.textContent = (t.coldef_gen_failed || "생성 실패: ") + (data.error || "Unknown error");
+            statusDiv.textContent = (t.coldef_gen_failed || "Generation failed: ") + (data.error || "Unknown error");
             statusDiv.style.color = "var(--red)";
         }
     } catch (err) {
-        statusDiv.textContent = (t.coldef_gen_failed || "생성 실패: ") + err.message;
+        statusDiv.textContent = (t.coldef_gen_failed || "Generation failed: ") + err.message;
         statusDiv.style.color = "var(--red)";
     } finally {
         autogenBtn.disabled = false;
-        autogenBtn.textContent = t.coldef_autogen_btn || "🤖 컬럼 정의 자동 생성";
+        autogenBtn.textContent = t.coldef_autogen_btn || "🤖 Auto-generate Column Definitions";
     }
 }
 
@@ -268,8 +268,8 @@ function showColdefReview(coldefArray) {
 function renderColdefTable(coldefArray) {
     const t = translations[currentLang];
     const tableDiv = document.getElementById("coldef-review-table");
-    const headerName = t.coldef_table_col_name || "컬럼명";
-    const headerDesc = t.coldef_table_col_desc || "설명";
+    const headerName = t.coldef_table_col_name || "Column";
+    const headerDesc = t.coldef_table_col_desc || "Description";
 
     let html = `<table class="coldef-table"><thead><tr><th>${headerName}</th><th>${headerDesc}</th></tr></thead><tbody>`;
     for (const col of coldefArray) {
@@ -306,7 +306,7 @@ function updateViewToggleBtn() {
         btn.textContent = t.coldef_view_json || "{ } JSON";
         btn.classList.remove("btn-view-active");
     } else {
-        btn.textContent = t.coldef_view_table || "📊 테이블";
+        btn.textContent = t.coldef_view_table || "📊 Table";
         btn.classList.add("btn-view-active");
     }
 }
@@ -324,7 +324,7 @@ function toggleColdefEdit() {
         document.getElementById("coldef-review-table").classList.add("hidden");
         editor.classList.remove("hidden");
         editor.focus();
-        btn.textContent = t.coldef_preview_btn || "👁 미리보기";
+        btn.textContent = t.coldef_preview_btn || "👁 Preview";
     } else {
         // Validate JSON on switch back
         try {
@@ -348,7 +348,7 @@ function toggleColdefEdit() {
             preview.classList.remove("hidden");
             document.getElementById("coldef-review-table").classList.add("hidden");
         }
-        btn.textContent = t.coldef_edit_btn || "✏️ 직접 수정";
+        btn.textContent = t.coldef_edit_btn || "✏️ Edit";
     }
 }
 
@@ -370,7 +370,7 @@ function confirmColdef() {
     selectedDiv.textContent = "";
     const span = document.createElement("span");
     span.className = "file-selected";
-    span.textContent = "🤖 " + (t.coldef_auto_generated || "자동 생성됨: column_definitions.json") + " ";
+    span.textContent = "🤖 " + (t.coldef_auto_generated || "Auto-generated: column_definitions.json") + " ";
     const removeBtn = document.createElement("span");
     removeBtn.className = "remove-file";
     removeBtn.title = "Remove";
@@ -413,7 +413,7 @@ function refreshSelectedFileDisplays() {
         selectedColdef.textContent = "";
         const span = document.createElement("span");
         span.className = "file-selected";
-        span.textContent = "🤖 " + (t.coldef_auto_generated || "자동 생성됨: column_definitions.json") + " ";
+        span.textContent = "🤖 " + (t.coldef_auto_generated || "Auto-generated: column_definitions.json") + " ";
         const removeBtn = document.createElement("span");
         removeBtn.className = "remove-file";
         removeBtn.title = "Remove";

--- a/docs/features/20260411_kyutae-JSON_Generation.md
+++ b/docs/features/20260411_kyutae-JSON_Generation.md
@@ -1,0 +1,120 @@
+# Auto-Generate Column Definitions (JSON Generation)
+
+Automatically generates `column_definitions.json` from uploaded CSV files using Amazon Bedrock (Claude), so users no longer need to manually create column definition files.
+
+## Overview
+
+Column definitions help the analysis agents understand domain-specific column meanings (e.g., "sales" = net vs gross) and formulas. Previously, users had to manually author a JSON file — a barrier for non-technical users.
+
+This feature reads the CSV header and sample rows, sends them to Claude Haiku via Bedrock, and returns a structured `column_definitions.json` for user review before upload.
+
+## Workflow
+
+```
+User uploads CSV
+       ↓
+[🤖 Auto-generate] button appears as primary action
+       ↓
+Backend reads CSV header + 5 sample rows
+       ↓
+Bedrock Claude Haiku generates column definitions
+       ↓
+Review panel with Table / JSON toggle
+       ↓
+User: Confirm | Regenerate | Edit manually
+       ↓
+Confirmed JSON attached to upload as column_definitions.json
+```
+
+## Changes
+
+### Backend (`deep-insight-web/app.py`)
+
+- **New endpoint**: `POST /generate-column-definitions`
+  - Accepts: `data_file` (CSV upload), `lang` (form field: `ko` or `en`)
+  - Parses CSV header + first 5 sample rows using Python `csv` module
+  - Calls `us.anthropic.claude-haiku-4-5-20251001-v1:0` via `bedrock-runtime` `invoke_model`
+  - Strips markdown code fences from LLM response if present
+  - Validates and returns parsed JSON array
+  - Returns `{ success: true, column_definitions: [...] }`
+
+### Frontend (`deep-insight-web/static/`)
+
+#### `index.html`
+- Restructured column definitions section for improved UX:
+  - **Auto-generate button placed above** the manual upload drop zone as the primary action
+  - "or" divider separates auto-generate (primary) from manual JSON upload (secondary)
+  - `selected-coldef` display moved above both options for visibility when a file is confirmed
+- Added review panel with:
+  - Table/JSON view toggle button
+  - Regenerate and Edit buttons
+  - JSON editor (textarea) for manual edits
+  - Table view (`<table>`) for readable column preview
+  - Confirm and Cancel action buttons
+
+#### `js/upload.js`
+- `updateAutogenVisibility()` — Shows/hides auto-generate button and "or" divider together when a data file is selected but no column definition JSON is provided
+- `hideAutogenArea()` — Hides auto-generate area, divider, review panel, and resets state
+- `generateColdef()` — Calls `/generate-column-definitions` endpoint, hides divider on success
+- `showColdefReview()` / `renderColdefTable()` — Renders generated definitions in both table and JSON views
+- `toggleColdefView()` — Switches between table and JSON display modes
+- `toggleColdefEdit()` — Toggles inline JSON editor with validation on exit
+- `confirmColdef()` — Converts generated JSON to a `Blob`, attaches to upload `FormData`, hides divider
+- `cancelColdef()` — Dismisses the review panel and resets state
+- `refreshSelectedFileDisplays()` — Re-renders dynamically created file selection badges on language change (data file, coldef file, auto-generated coldef badge, review table headers)
+- Modified upload form submission to include auto-generated column definitions when no manual file is provided
+
+#### `js/i18n.js`
+- Added Korean and English translations for all new UI elements:
+  - Auto-generate button, description hint (`coldef_autogen_desc`), loading state, error messages
+  - Review panel title, action buttons
+  - Table/JSON toggle labels
+  - Table column headers ("Column" / "Description")
+- `applyLanguage()` now calls `refreshSelectedFileDisplays()` to update dynamically rendered text (e.g., "Selected:" / "선택됨:") on language toggle
+
+#### `css/styles.css`
+- `.btn-autogen-primary` — Prominent CTA button with gradient background, white text, `✨` icon, hover lift effect, and active press feedback
+- `.coldef-autogen-desc` — Centered description text below the auto-generate button
+- `.drop-zone-secondary` — Reduced-prominence drop zone for manual JSON upload (smaller padding, lower opacity)
+- `.autogen-divider` — "or" divider with horizontal lines between primary and secondary options
+- `.coldef-review-panel` — Review panel container with green accent border
+- `.coldef-table` — Styled table with sticky header, hover rows, monospace column names
+- `.btn-view-active` — Active state for view toggle button with accent shadow
+- `.btn-sm` — Small button variant with slightly increased padding
+- `.btn-outline` — Outline button with elevated background, box-shadow, hover lift/glow effect, and active press feedback
+
+## User Experience
+
+The auto-generate option is presented as the **primary** action for column definitions, with manual JSON upload as a secondary "or" alternative below it. This reduces friction for non-technical users who don't have a pre-authored JSON file.
+
+```
+Column Definitions (Recommended)
+┌─────────────────────────────────────┐
+│  🤖 Auto-generate Column Defs   ✨  │  ← Primary (gradient bg, prominent)
+│  AI generates definitions from      │
+│  your uploaded data file            │
+└─────────────────────────────────────┘
+              ── or ──
+┌ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┐
+   📄 Drop JSON file here              ← Secondary (smaller, dashed)
+└ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ┘
+```
+
+| User Type | Flow |
+|-----------|------|
+| No JSON file | Upload data file → Click "Auto-generate" (primary) → Review table → Confirm → Upload |
+| Wants to customize | Auto-generate → Click "Edit" → Modify JSON → Confirm → Upload |
+| Has JSON file | Upload data file → Scroll past auto-generate → Drop JSON (secondary) → Upload |
+
+### Language Behavior
+
+- Column descriptions are generated in the **language active at generation time** (Korean or English)
+- Column names always match the original CSV headers regardless of language
+- Switching language after generation does **not** auto-translate descriptions — user should click "Regenerate" to get descriptions in the new language
+- All UI labels (buttons, table headers, file badges) update dynamically on language toggle
+
+## Model Configuration
+
+- **Model**: `us.anthropic.claude-haiku-4-5-20251001-v1:0` (cross-region inference profile)
+- **Max tokens**: 2048
+- **Language**: Determined by the UI language toggle (Korean / English) at generation time

--- a/managed-agentcore/.env.example
+++ b/managed-agentcore/.env.example
@@ -34,6 +34,7 @@ AWS_ACCOUNT_ID=<YOUR_AWS_ACCOUNT_ID>
 # Bedrock Model Configuration
 # ============================================================
 
+WEB_UTILITY_MODEL_ID=global.anthropic.claude-haiku-4-5-20251001-v1:0
 DEFAULT_MODEL_ID=global.anthropic.claude-sonnet-4-6
 COORDINATOR_MODEL_ID=global.anthropic.claude-haiku-4-5-20251001-v1:0
 PLANNER_MODEL_ID=global.anthropic.claude-sonnet-4-6


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added auto-generate column definitions feature to Deep Insight.

Previously users had to manually author a column_definitions.json file. Now they can just upload a CSV and click "Auto-generate" — AI (Bedrock Claude Haiku) analyzes the headers + sample rows and generates column descriptions automatically.

Review generated definitions in table or JSON view, with options to confirm, edit, or regenerate
Auto-generate is the primary action; manual JSON upload is still available as a secondary option
Column descriptions are generated in Korean or English based on the UI language setting
Lowers the barrier for non-technical users who found JSON authoring difficult.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
