### PR TITLE
[FIX] envload + chart style + sticky tables (and Data Q&A News entry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 ## *Latest News* 🔥
 
+- **[2026/06]** Data Q&A — natural-language chat over the uploaded CSV with DuckDB Text2SQL, sandboxed in-process (no data leaves your AWS account), Bedrock prompt caching for ~90% input-token savings on multi-turn dialogue, and an inline SQL editor so analysts can inspect, edit, and re-run the generated SQL without another LLM call. ([details](./deep-insight-web/README.md#data-qa))
 - **[2026/04]** Auto-generate sample analysis prompts — AI generates 3 sample prompts (간단/중간/복잡 — simple/medium/complex) from your column-definitions JSON, replacing the previous hard-coded fallback chips. Each generated prompt references actual column names so it's immediately runnable. ([details](./docs/features/prompt-generation/README.md))
 - **[2026/04]** Auto-generate column definitions — AI builds `column_definitions.json` from a CSV header + sample rows, removing the manual JSON-authoring barrier for non-technical users. Includes a Table/JSON review panel with manual edit support. ([details](./docs/features/json-generation/README.md))
 - **[2026/04]** CloudFront + Cognito deployment option for Web UI — HTTPS with Lambda@Edge authentication for external demos and customer PoCs ([details](./deep-insight-web/README.md))


### PR DESCRIPTION
  ## 변경 사항

  ### Fixes (c63f08e)
  - `app.py`의 `load_dotenv`를 `chat_agent`/`ops` import 위로 이동 — 로컬 실행 시 `S3_BUCKET_NAME`이 빈값으로 굳어 "Failed to
  load dataset metadata"로 떨어지던 버그 수정. 컨테이너 배포(.env 부재)에는 영향 없음.
  - `chat_agent.py` 시각화 가드 보강:
    - `bar_label`을 필수, `ax.text`/manual loop를 명시적 금지 (라벨↔막대 인덱스 어긋남으로 인한 silent data-correctness 사고
  차단)
    - `fmt`은 callable(lambda)만 허용, `"%,.0f"` 같은 old-style 포맷 금지 (Python `%` 포매터가 천단위 콤마 미지원으로 fmt
  문자열을 그대로 인쇄하는 문제 차단)
    - KRW 단위 변환은 *plot 전 df에서* 나누기로 통일, axis tick과 bar value 단위 정합성 보장
  - `static/css/styles.css` 결과 테이블에 `max-height: 420px` + sticky header — 길이가 긴 결과(예: 100행+)가 페이지 전체
  스크롤을 가져가지 않고 결과창 내부에서 스크롤됨
  
  ### Docs (dd65863)
  - 메인 README의 *Latest News*에 Data Q&A 진입 한 줄 추가 (#62 머지 반영)
