### PR TITLE
fix(fargate): retry session completion and harden S3 upload to prevent report loss

### DIFF
--- a/managed-agentcore/agentcore_runtime.py
+++ b/managed-agentcore/agentcore_runtime.py
@@ -153,10 +153,10 @@ def cleanup_fargate_session() -> None:
             print("📤 Initiating final S3 upload and waiting for completion...", flush=True)
             completion_result = fargate_manager._session_manager.complete_session(wait_for_s3=True)
 
-            if completion_result and completion_result.get("status") == "success":
+            if completion_result and completion_result.get("upload_completed"):
                 print("✅ S3 upload confirmed - all Fargate artifacts uploaded", flush=True)
             else:
-                print("⚠️ S3 upload status unclear, but proceeding with cleanup", flush=True)
+                print("⚠️ S3 upload NOT confirmed - proceeding with forced task cleanup", flush=True)
 
         # 2. Force cleanup of all Fargate tasks (fail-safe)
         print("🔍 Checking for any remaining Fargate tasks...", flush=True)

--- a/managed-agentcore/fargate-runtime/code_executor_server.py
+++ b/managed-agentcore/fargate-runtime/code_executor_server.py
@@ -119,6 +119,7 @@ from io import StringIO
 import contextlib
 import unicodedata
 import boto3
+from botocore.config import Config as BotoConfig
 from flask import Flask, request, jsonify
 from pathlib import Path
 import shutil
@@ -164,11 +165,22 @@ class SessionManager:
             self.complete_session()
 
     def complete_session(self):
-        """Complete session - Upload all results to S3"""
-        if self.is_complete:
-            return
+        """Complete session - Upload all results to S3.
 
-        self.is_complete = True
+        Returns:
+            bool: True if the S3 upload completed successfully, False otherwise.
+
+        Idempotency: if a previous call already finished the upload
+        (is_complete=True), returns True immediately without re-uploading.
+        If a previous attempt FAILED, is_complete is reset to False so a
+        subsequent retry (from the runtime or auto-shutdown) can re-run the
+        upload — this prevents a single transient error from permanently
+        losing the generated report.
+        """
+        if self.is_complete:
+            # Already uploaded successfully on a prior call - nothing to do.
+            return True
+
         print(f"🏁 Session {self.session_id} complete. Uploading to S3...", flush=True)
 
         try:
@@ -181,12 +193,18 @@ class SessionManager:
                 "executions": self.executions
             }
 
-            # Upload to S3
+            # Upload to S3 (raises on any artifact upload failure)
             self.upload_to_s3(session_result)
 
+            # Only mark complete AFTER a confirmed successful upload, so a
+            # failed attempt leaves the session retryable.
+            self.is_complete = True
             print(f"✅ Session {self.session_id} uploaded to S3", flush=True)
+            return True
         except Exception as e:
-            print(f"❌ Failed to upload session to S3: {e}", flush=True)
+            # Keep is_complete=False so the next retry can re-attempt the upload.
+            print(f"❌ Failed to upload session to S3 (will remain retryable): {e}", flush=True)
+            return False
 
     def upload_to_s3(self, session_result):
         """Upload session results and generated files to S3"""
@@ -199,7 +217,17 @@ class SessionManager:
         if not bucket:
             raise ValueError("S3_BUCKET_NAME environment variable is required but not set")
 
-        s3_client = boto3.client('s3', region_name=aws_region)
+        # Resilient S3 client: adaptive retries absorb transient errors such as
+        # "Connection reset by peer" (ECONNRESET) that previously caused the
+        # final report to be silently dropped. Explicit timeouts prevent a hung
+        # socket from blocking completion indefinitely.
+        s3_config = BotoConfig(
+            retries={'max_attempts': 10, 'mode': 'adaptive'},
+            connect_timeout=10,
+            read_timeout=120,
+            max_pool_connections=20,
+        )
+        s3_client = boto3.client('s3', region_name=aws_region, config=s3_config)
 
         print(f"☁️ Starting S3 upload to s3://{bucket}/deep-insight/fargate_sessions/{self.session_id}/", flush=True)
 
@@ -244,9 +272,23 @@ class SessionManager:
 
         print(f"✅ S3 upload completed for session {self.session_id}", flush=True)
 
+    # Per-file upload retry (on top of the boto3 client-level adaptive retries).
+    # Guards against a transient error striking the same file repeatedly.
+    UPLOAD_FILE_MAX_ATTEMPTS = 3
+    UPLOAD_FILE_RETRY_BASE = 2  # seconds; exponential backoff 2s, 4s, ...
+
     def _upload_directory_to_s3(self, s3_client, bucket, local_dir, s3_prefix):
-        """Upload all files in directory to S3"""
+        """Upload all files in a directory to S3.
+
+        Raises:
+            Exception: if any file fails to upload after all retries. Surfacing
+            the failure (instead of swallowing it) lets complete_session() report
+            an accurate failure status so the caller can retry the whole session
+            completion — previously a dropped report was logged but reported as
+            success, hiding the data loss.
+        """
         uploaded_count = 0
+        failures = []
 
         for root, dirs, files in os.walk(local_dir):
             for file in files:
@@ -254,32 +296,54 @@ class SessionManager:
                 relative_path = os.path.relpath(local_file_path, local_dir)
                 s3_key = f"{s3_prefix}/{relative_path}".replace('\\', '/')
 
-                try:
-                    # Set ContentType based on file extension
-                    content_type = 'application/octet-stream'
-                    if file.endswith('.json'):
-                        content_type = 'application/json'
-                    elif file.endswith('.txt'):
-                        content_type = 'text/plain'
-                    elif file.endswith('.csv'):
-                        content_type = 'text/csv'
-                    elif file.endswith('.png'):
-                        content_type = 'image/png'
-                    elif file.endswith('.jpg') or file.endswith('.jpeg'):
-                        content_type = 'image/jpeg'
-                    elif file.endswith('.pdf'):
-                        content_type = 'application/pdf'
-                    elif file.endswith('.py'):
-                        content_type = 'text/x-python'
+                # Set ContentType based on file extension
+                content_type = 'application/octet-stream'
+                if file.endswith('.json'):
+                    content_type = 'application/json'
+                elif file.endswith('.txt'):
+                    content_type = 'text/plain'
+                elif file.endswith('.csv'):
+                    content_type = 'text/csv'
+                elif file.endswith('.png'):
+                    content_type = 'image/png'
+                elif file.endswith('.jpg') or file.endswith('.jpeg'):
+                    content_type = 'image/jpeg'
+                elif file.endswith('.pdf'):
+                    content_type = 'application/pdf'
+                elif file.endswith('.py'):
+                    content_type = 'text/x-python'
 
-                    s3_client.upload_file(
-                        local_file_path, bucket, s3_key,
-                        ExtraArgs={'ContentType': content_type}
-                    )
-                    uploaded_count += 1
-                    print(f"    📤 {relative_path} → s3://{bucket}/{s3_key}", flush=True)
-                except Exception as e:
-                    print(f"    ❌ Upload failed for {relative_path}: {e}", flush=True)
+                last_error = None
+                for attempt in range(1, self.UPLOAD_FILE_MAX_ATTEMPTS + 1):
+                    try:
+                        s3_client.upload_file(
+                            local_file_path, bucket, s3_key,
+                            ExtraArgs={'ContentType': content_type}
+                        )
+                        uploaded_count += 1
+                        print(f"    📤 {relative_path} → s3://{bucket}/{s3_key}", flush=True)
+                        last_error = None
+                        break
+                    except Exception as e:
+                        last_error = e
+                        if attempt < self.UPLOAD_FILE_MAX_ATTEMPTS:
+                            wait = self.UPLOAD_FILE_RETRY_BASE ** attempt
+                            print(f"    ⚠️ Upload attempt {attempt}/{self.UPLOAD_FILE_MAX_ATTEMPTS} "
+                                  f"failed for {relative_path}: {e} - retrying in {wait}s", flush=True)
+                            time.sleep(wait)
+                        else:
+                            print(f"    ❌ Upload failed for {relative_path} after "
+                                  f"{self.UPLOAD_FILE_MAX_ATTEMPTS} attempts: {e}", flush=True)
+
+                if last_error is not None:
+                    failures.append((relative_path, last_error))
+
+        if failures:
+            # Re-raise so complete_session() knows the upload did NOT fully succeed.
+            failed_names = ', '.join(name for name, _ in failures)
+            raise RuntimeError(
+                f"{len(failures)} file(s) failed to upload to S3: {failed_names}"
+            )
 
         return uploaded_count
 
@@ -642,11 +706,22 @@ def complete_session():
             "error": "Session ID mismatch - completion request routed to wrong container"
         }), 403
 
-    session_manager.complete_session()
+    upload_ok = session_manager.complete_session()
+    if not upload_ok:
+        # Signal failure so the runtime's retry logic re-attempts completion
+        # instead of tearing down the container with the report still local.
+        return jsonify({
+            "message": "Session completion failed - S3 upload did not finish",
+            "session_id": session_manager.session_id,
+            "total_executions": len(session_manager.executions),
+            "upload_completed": False
+        }), 500
+
     return jsonify({
         "message": "Session completed",
         "session_id": session_manager.session_id,
-        "total_executions": len(session_manager.executions)
+        "total_executions": len(session_manager.executions),
+        "upload_completed": True
     })
 
 @app.route('/file-sync', methods=['POST'])

--- a/managed-agentcore/src/tools/fargate_container_controller.py
+++ b/managed-agentcore/src/tools/fargate_container_controller.py
@@ -116,10 +116,17 @@ class SessionBasedFargateManager:
     TASK_IP_POLL_INTERVAL = 3          # Polling interval for task IP check (seconds)
     HEALTH_CHECK_TIMEOUT = 5           # Timeout for container health check (seconds)
     CODE_EXECUTION_TIMEOUT = 600       # Timeout for code execution (seconds) - Increased for long-running tasks like DOCX generation
-    SESSION_COMPLETE_TIMEOUT = 10      # Timeout for session completion signal (seconds)
+    SESSION_COMPLETE_TIMEOUT = 60      # Timeout for session completion signal (seconds) - upload runs synchronously on the container
     STATUS_CHECK_TIMEOUT = 5           # Timeout for session status check (seconds)
     S3_UPLOAD_WAIT = 15                # Wait time for S3 upload completion (seconds)
     CONTAINER_PORT = 8080              # Container HTTP port
+
+    # Session completion retry (guards against transient "Connection reset by
+    # peer" on the completion-trigger HTTP call, which previously dropped the
+    # final report). Backoff is generous because the single-threaded container
+    # may be busy uploading and unable to answer immediately.
+    SESSION_COMPLETE_MAX_RETRIES = 4   # Total attempts for the completion HTTP call
+    SESSION_COMPLETE_RETRY_BASE = 2    # seconds; exponential backoff 2s, 4s, 8s, ...
 
     # ========================================================================
     # HELPER METHODS (DRY - Don't Repeat Yourself)
@@ -571,43 +578,85 @@ class SessionBasedFargateManager:
         print(f"🏁 [Session {session_id}] Completing session...", flush=True)
 
         try:
+            self._ensure_http_session()
+        except Exception:
+            print(f"⚠️ HTTP session not available for completion", flush=True)
+            return {"error": "No HTTP session"}
+
+        # 1. Send session completion signal, retrying on transient failures.
+        #    The container uploads all artifacts (including the final report)
+        #    synchronously when it receives this request, so a single dropped
+        #    request (e.g. "Connection reset by peer") must NOT be treated as
+        #    completion - otherwise the report is lost. We only proceed to tear
+        #    down the container after a confirmed HTTP 200 (upload_completed).
+        result = {}
+        upload_confirmed = False
+        last_error = None
+
+        for attempt in range(1, self.SESSION_COMPLETE_MAX_RETRIES + 1):
             try:
-                self._ensure_http_session()
-            except Exception:
-                print(f"⚠️ HTTP session not available for completion", flush=True)
-                return {"error": "No HTTP session"}
+                # Include session_id so the container can reject misrouted requests
+                response = self.http_session.post(
+                    f"http://{self.alb_dns}/session/complete",
+                    json={"session_id": session_id},
+                    timeout=self.SESSION_COMPLETE_TIMEOUT
+                )
 
-            # 1. Send session completion signal (🍪 use http_session - per-request isolation)
-            # Include session_id so the container can reject misrouted requests
-            response = self.http_session.post(
-                f"http://{self.alb_dns}/session/complete",
-                json={"session_id": session_id},
-                timeout=self.SESSION_COMPLETE_TIMEOUT
-            )
-            result = response.json() if response.status_code == 200 else {}
+                if response.status_code == 200:
+                    result = response.json() if response.content else {}
+                    upload_confirmed = True
+                    print(f"✅ [Session {session_id}] Completion confirmed by container "
+                          f"(attempt {attempt}/{self.SESSION_COMPLETE_MAX_RETRIES})", flush=True)
+                    break
 
-            # 2. Wait for S3 upload
-            if wait_for_s3:
-                print(f"⏳ Waiting for S3 upload...", flush=True)
-                time.sleep(self.S3_UPLOAD_WAIT)
+                # 500 => container received the request but the upload failed;
+                # it keeps the session retryable, so retrying is safe and useful.
+                last_error = f"HTTP {response.status_code}: {response.text[:200]}"
+                print(f"⚠️ [Session {session_id}] Completion attempt "
+                      f"{attempt}/{self.SESSION_COMPLETE_MAX_RETRIES} returned {last_error}", flush=True)
 
-            # 3. Session cleanup
-            self._cleanup_session(self.current_session)
+            except requests.exceptions.RequestException as e:
+                # Transient network error (connection reset, timeout, etc.).
+                # The request likely never reached the container, so the
+                # container's complete_session() is idempotent and safe to retry.
+                last_error = str(e)
+                print(f"⚠️ [Session {session_id}] Completion attempt "
+                      f"{attempt}/{self.SESSION_COMPLETE_MAX_RETRIES} failed: {e}", flush=True)
 
-            # 4. Reset current session information
-            self.current_session = None
+            if attempt < self.SESSION_COMPLETE_MAX_RETRIES:
+                wait = self.SESSION_COMPLETE_RETRY_BASE ** attempt
+                print(f"⏳ [Session {session_id}] Retrying completion in {wait}s...", flush=True)
+                time.sleep(wait)
 
-            print(f"✅ [Session {session_id}] Session completed successfully!", flush=True)
+        if not upload_confirmed:
+            # All retries exhausted. Do NOT deregister/stop the container here -
+            # leaving it alive lets the container's 1-hour auto-shutdown make a
+            # final upload attempt as a fail-safe. Report failure to the caller.
+            print(f"❌ [Session {session_id}] Completion FAILED after "
+                  f"{self.SESSION_COMPLETE_MAX_RETRIES} attempts: {last_error}", flush=True)
+            print(f"   ⏭️ Skipping container teardown so auto-shutdown can retry the S3 upload.", flush=True)
+            return {"error": last_error or "completion failed", "upload_completed": False}
 
-            return {
-                "session_id": session_id,
-                "status": "completed",
-                "total_executions": result.get('total_executions', 0)
-            }
+        # 2. Brief settle wait (upload already finished synchronously on the
+        #    container before it returned 200; this absorbs any S3 read-after-write lag)
+        if wait_for_s3:
+            print(f"⏳ Waiting for S3 upload to settle...", flush=True)
+            time.sleep(self.S3_UPLOAD_WAIT)
 
-        except Exception as e:
-            print(f"❌ [Session {session_id}] Error completing session: {e}", flush=True)
-            return {"error": str(e)}
+        # 3. Session cleanup (safe now: upload is confirmed complete)
+        self._cleanup_session(self.current_session)
+
+        # 4. Reset current session information
+        self.current_session = None
+
+        print(f"✅ [Session {session_id}] Session completed successfully!", flush=True)
+
+        return {
+            "session_id": session_id,
+            "status": "completed",
+            "total_executions": result.get('total_executions', 0),
+            "upload_completed": True
+        }
 
     def _cleanup_session(self, session_info: Dict[str, Any]):
         """Session cleanup (ALB deregister + Task stop)"""

--- a/managed-agentcore/src/tools/global_fargate_coordinator.py
+++ b/managed-agentcore/src/tools/global_fargate_coordinator.py
@@ -367,6 +367,12 @@ class GlobalFargateSessionManager:
                 logger.warning("⚠️ No request ID for cleanup")
                 return
 
+            # Tracks whether it is safe to finalize this request (drop HTTP
+            # client + block recreation). Stays True for the no-session paths;
+            # set False only when an S3 upload could not be confirmed, so we
+            # keep the session retryable for the auto-shutdown fail-safe.
+            upload_completed = True
+
             if cleanup_request_id in self._sessions:
                 session_info = self._sessions[cleanup_request_id]
                 logger.info(f"🧹 Cleaning up session for request {cleanup_request_id}: {session_info['session_id']}")
@@ -374,26 +380,52 @@ class GlobalFargateSessionManager:
                 container_ip = session_info.get('container_ip')
 
                 # FIX: Call complete_session() first (before ALB removal)
-                # 1. Allow container to upload to S3 first
+                # 1. Trigger the container's S3 upload (now retried internally on
+                #    transient errors like "Connection reset by peer").
                 logger.info(f"🏁 Completing session (S3 upload)...")
                 self._session_manager.current_session = session_info['fargate_session']
-                self._session_manager.complete_session()
+                completion_result = self._session_manager.complete_session()
+                upload_completed = bool(
+                    completion_result and completion_result.get("upload_completed")
+                )
 
-                # 2. Then release container IP and remove from ALB (safe now)
-                if container_ip and container_ip in self._used_container_ips:
-                    del self._used_container_ips[container_ip]
-                    logger.info(f"🧹 Released container IP: {container_ip}")
-                    logger.info(f"   Remaining IPs: {list(self._used_container_ips.keys())}")
+                if upload_completed:
+                    # 2. Upload confirmed → safe to release IP and tear down container.
+                    if container_ip and container_ip in self._used_container_ips:
+                        del self._used_container_ips[container_ip]
+                        logger.info(f"🧹 Released container IP: {container_ip}")
+                        logger.info(f"   Remaining IPs: {list(self._used_container_ips.keys())}")
 
-                    # Remove container from ALB Target Group (prevents zombie targets)
-                    # Execute after complete_session() to prevent HTTP 502 errors
-                    self._deregister_from_alb(container_ip)
+                        # Remove container from ALB Target Group (prevents zombie targets)
+                        # Execute after confirmed upload to prevent HTTP 502 errors
+                        self._deregister_from_alb(container_ip)
 
-                # Remove from session dictionary
-                del self._sessions[cleanup_request_id]
-                logger.info(f"✅ Session cleanup completed. Remaining sessions: {len(self._sessions)}")
+                    # Remove from session dictionary
+                    del self._sessions[cleanup_request_id]
+                    logger.info(f"✅ Session cleanup completed. Remaining sessions: {len(self._sessions)}")
+                else:
+                    # Upload NOT confirmed → leave the container registered and
+                    # alive so its 1-hour auto-shutdown can make a final upload
+                    # attempt. Do NOT delete the session here, so we don't lose
+                    # the ability to observe/retry it.
+                    logger.error(
+                        f"❌ S3 upload not confirmed for session "
+                        f"{session_info['session_id']} (request {cleanup_request_id}). "
+                        f"Leaving container alive for auto-shutdown fail-safe retry; "
+                        f"skipping ALB deregister and session deletion."
+                    )
             else:
                 logger.warning(f"⚠️ No session found for request {cleanup_request_id}")
+
+            if not upload_completed:
+                # Keep the HTTP client and do NOT block recreation: the session
+                # is intentionally left alive so the upload can still complete
+                # (via container auto-shutdown). Finalizing here would orphan it.
+                logger.warning(
+                    f"⚠️ Skipping final cleanup for request {cleanup_request_id} "
+                    f"because the S3 upload was not confirmed."
+                )
+                return
 
             # Clean up HTTP client (remove cookies)
             if cleanup_request_id in self._http_clients:


### PR DESCRIPTION
## Problem

The final report (DOCX) and chart files could be silently lost at the end of a session.
Only `token_usage.json`/`.txt` survived, because the runtime uploads those separately.

Observed in production logs:🏁 [Session 2026-06-24-05-00-30-2999f14b] Completing session...
❌ Error completing session: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
🧹 Released container IP: 10.0.1.141
🔗 Deregistered target from ALB: 10.0.1.141:8080
✅ Session cleanup completed.   ← reported success, report was never uploaded

## Root cause

The `/session/complete` POST — which triggers the container's synchronous S3 upload
of all artifacts — was fired **once with no retry**. On a transient
`Connection reset by peer`, the coordinator still proceeded to deregister the
container from the ALB, stop the task, and block session recreation, destroying
the only copy of the report. Per-file upload errors inside the container were
also swallowed and logged, so failures were reported as success.

## Changes

- **`fargate_container_controller.complete_session`**: retry the completion POST
  with exponential backoff (4 attempts); tear down the container only after a
  confirmed HTTP 200. On exhaustion, leave the container alive so its 1-hour
  auto-shutdown can make a final upload attempt. `SESSION_COMPLETE_TIMEOUT`
  10s → 60s (upload runs synchronously). Returns `upload_completed`.
- **`global_fargate_coordinator.cleanup_session`**: deregister/stop/forget the
  session only when `upload_completed` is confirmed; otherwise keep it retryable.
- **`code_executor_server`**: resilient boto3 S3 client (adaptive retries +
  timeouts); per-file upload retry; re-raise on persistent failure instead of
  swallowing; mark `is_complete` only after a confirmed upload (idempotent +
  retryable); `/session/complete` returns HTTP 500 on upload failure.
- **`agentcore_runtime`**: check `upload_completed` in the atexit fail-safe.

## Testing

Verified with a mock-based test suite reproducing the exact failure from the logs
(`ConnectionResetError(104)` on the completion call) — 11/11 passed:

- Container: failed upload stays retryable then succeeds; idempotent after success;
  per-file retry recovers transient errors; persistent failure raises;
  endpoint returns 500/200 with accurate `upload_completed`
- Controller: reset ×2 then 200 → teardown only after confirmation;
  all retries fail → container left alive, session kept
- Coordinator: unconfirmed upload → session/IP/ALB target/HTTP client all preserved,
  recreation not blocked; confirmed → full cleanup
- End-to-end: upload fails once → 500 → retry → upload succeeds → confirmed → teardown