### PR TITLE
[FIX] Reclaim zombie Fargate containers on failed session completion (Tier 1+2)

### DIFF
--- a/docs/superpowers/specs/2026-07-08-fargate-zombie-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-08-fargate-zombie-cleanup-design.md
@@ -8,6 +8,8 @@
   - `managed-agentcore/fargate-runtime/code_executor_server.py` (one line: `sys.exit(0)` → `os._exit(0)` in `auto_shutdown`)
 - **Supersedes:** the pre-merge draft, which *assumed* #107 as an unmerged premise. This version was re-validated against the actual merged code.
 
+
+
 ## Baseline (post-#107, verified in code)
 
 On a completion failure the merged system now does:
@@ -22,43 +24,63 @@ So the "failed flow" (keep-alive → salvage → reclaim gap) now genuinely exis
 1. On the failure path the **ALB target + coordinator state (IP, session) leak** — nothing reclaims them (no reaper).
 2. `auto_shutdown`'s `sys.exit(0)` runs in a **daemon thread**, so it raises `SystemExit` only in that thread and does **not** terminate the process — the Fargate task never self-terminates on the failure path (empirically verified). The salvage upload runs, but the task lingers until externally stopped.
 
+
+
 ## Changes
 
+
+
 ### Change 0 — `os._exit` in `auto_shutdown` (container)
+
 `code_executor_server.py`, `auto_shutdown` (~L881): replace `sys.exit(0)` with `os._exit(0)` so the daemon-thread shutdown actually terminates the process (and the Fargate task) after the boot+1h salvage. `os._exit` is appropriate: the salvage upload has already run, all logs use `flush=True`, and the container has no critical atexit handlers. (This is the earlier commit `59dd18d`, now valid on the post-#107 baseline; re-applied on this branch.)
 
 ### Tier 1 — deregister the ALB target on the failure path (coordinator)
+
 In `cleanup_session`'s upload-not-confirmed branch: `_deregister_from_alb(container_ip)` immediately. Safe because the salvage upload is a direct boto3→S3 call that does **not** use the ALB, so removing the target prevents a permanent zombie in the target group. Do **not** StopTask (the container must live to salvage). Record the orphan (see Tier 2) and keep the IP held.
 
 ### Tier 2 — orphan tracking + reclaim-on-allocate sweep (coordinator)
 
-- **`_orphaned_sessions` dict — REVISED from the draft's in-place flag.** On the failure path, **move** the session record out of `_sessions` into `_orphaned_sessions[req_id] = {task_arn, container_ip, session_id, orphaned_at}` and **delete it from `_sessions`**. Keep the IP in `_used_container_ips` (the container still holds it).
+- `_orphaned_sessions` **dict — REVISED from the draft's in-place flag.** On the failure path, **move** the session record out of `_sessions` into `_orphaned_sessions[req_id] = {task_arn, container_ip, session_id, orphaned_at}` and **delete it from** `_sessions`. Keep the IP in `_used_container_ips` (the container still holds it).
   - **Why moved, not flagged:** if the orphan stayed in `_sessions`, `ensure_session` (L224: `if req_id in self._sessions: return self._reuse_existing_session()`) would try to **reuse** it on a same-`request_id` retry — but Tier 1 removed its ALB target, so reuse would target a deregistered/dying container. Moving it out makes `ensure_session` create a **fresh** session instead, and gives the sweep a clean worklist. (Surfaced by the "think-it-over" pass and the review workflow.)
-- **`_is_tasks_stopped(task_arns) -> set(stopped_arns)` — REVISED: batched.** One `ecs.describe_tasks` call for up to 100 ARNs. Classify a task as stopped when `lastStatus == 'STOPPED'` **or** it is absent from the response (already gone). On any API error, treat all as **not** stopped (conservative — never reclaim while the container may still hold its IP).
-- **`_reclaim_stopped_orphans()`.** Batch-check every `_orphaned_sessions` entry; for each stopped one, reclaim: `_deregister_from_alb` (idempotent) + drop IP from `_used_container_ips` + drop `_http_clients[req_id]` + delete from `_orphaned_sessions` + add `req_id` to `_cleaned_up_requests`. Best-effort; log each reclaim; never raise into the request path.
+- `_is_tasks_stopped(task_arns) -> set(stopped_arns)` **— REVISED: batched.** One `ecs.describe_tasks` call for up to 100 ARNs. Classify a task as stopped when `lastStatus == 'STOPPED'` **or** it is absent from the response (already gone). On any API error, treat all as **not** stopped (conservative — never reclaim while the container may still hold its IP).
+- `_reclaim_stopped_orphans()`**.** Batch-check every `_orphaned_sessions` entry; for each stopped one, reclaim: `_deregister_from_alb` (idempotent) + drop IP from `_used_container_ips` + drop `_http_clients[req_id]` + delete from `_orphaned_sessions` + add `req_id` to `_cleaned_up_requests`. Best-effort; log each reclaim; never raise into the request path.
 - **Hook.** `ensure_session()` calls `_reclaim_stopped_orphans()` at entry (once per request, before the reuse/create decision).
 
+
+
 ## Error handling & concurrency
+
 - Sweep/helper are **best-effort** — never raise into the request path.
 - **Conservative reclaim** on unknown task status (do not free a held IP while unsure the task is dead).
 - **Lock-free safety:** the sweep only touches `_orphaned_sessions` whose task is `STOPPED`; active sessions live in `_sessions` and are `RUNNING`, so never eligible. A `list(...)` snapshot avoids "dict changed during iteration." No new race surface versus the existing lock-free code. A real concurrency fix (locking + background reaper) is Tier 3, out of scope.
 
+
+
 ## Known limitations (documented, not fixed here)
+
 - **Salvage is best-effort:** `auto_shutdown` calls `complete_session()` then `os._exit(0)` unconditionally; a persistent S3 failure — or the task dying earlier (spot reclaim / OOM / crash) — still loses the report permanently. Inherent to ephemeral container storage.
 - **Out-of-band recovery:** a successful salvage lands in S3 up to ~1h after the user already saw a failure — it protects the artifact, not the live request UX.
-- **Absolute (not idle) 1h timer:** a failure early in a container's life leaves it alive up to ~57 min before the salvage retry and before the reclaim sweep can find it `STOPPED`.
+- **Absolute (not idle) 1h timer:** a failure early in a container's life leaves it alive up to ~57 min before the salvage retry and before the reclaim sweep can find it `STOPPED`. The single boot-relative timer *doubles as* the max-session-lifetime cap (`auto_shutdown` force-completes and exits **any** session still running at 1h), so it **cannot simply be shortened** — lowering the constant would force-terminate legitimate long analyses (up to 500 executions × ≤600 s each) mid-run. Reducing the salvage delay requires *decoupling* the two roles (see Out of scope), not changing the value.
 - **Unbounded until next request:** with no subsequent request, orphans linger in memory (bounded by process lifetime). The ALB target is already removed by Tier 1, so the AWS-side zombie is gone regardless.
 
+
+
 ## Testing
+
 No test framework (per `CLAUDE.md`); mock-based like #107. Stub the ECS client / `_is_tasks_stopped` and assert:
+
 - `STOPPED` orphan → removed from `_orphaned_sessions` + `_used_container_ips` + `_http_clients`, added to `_cleaned_up_requests`, ALB deregister called.
 - `RUNNING` orphan → untouched.
 - `describe_tasks` error → nothing reclaimed.
 - `ensure_session` for a same `request_id` after tagging → creates a **fresh** session (does not reuse the orphan).
 - batched `describe_tasks` → a **single** call for N orphans.
 
+
+
 ## Observability
+
 ERROR log when a session is orphaned; INFO on each reclaim. CloudWatch metric / leak cap: deferred (YAGNI).
 
 ## Out of scope
-Tier 3 (background reaper thread, ALB↔task reconciliation for crash-orphans, singleton locking, metrics/cap). No further container changes beyond `os._exit`. The full review-workflow transcript (25 findings; 2 pre-#107 criticals now resolved by the merge) lives in the session's workflow journal.
+
+Tier 3 (background reaper thread, ALB↔task reconciliation for crash-orphans, singleton locking, metrics/cap). No further container changes beyond `os._exit`. **Decoupling the 1h timer** — making the lifetime cap idle-based (reset on execution activity) and adding a dedicated short post-failure salvage-retry loop, both container-side — is deferred to a separate PR. The full review-workflow transcript (25 findings; 2 pre-#107 criticals now resolved by the merge) lives in the session's workflow journal.

--- a/docs/superpowers/specs/2026-07-08-fargate-zombie-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-08-fargate-zombie-cleanup-design.md
@@ -1,0 +1,64 @@
+# Design: Fargate container "zombie" cleanup (Tier 1 + Tier 2) — revised on the merged #107 baseline
+
+- **Date:** 2026-07-08
+- **Status:** Approved design (revised)
+- **Baseline:** PR #107 is **MERGED** (merge commit `6e472a9`). This design *builds on* #107's post-merge behavior — it does not re-describe it.
+- **Scope (files):**
+  - `managed-agentcore/src/tools/global_fargate_coordinator.py` (Tier 1 + Tier 2)
+  - `managed-agentcore/fargate-runtime/code_executor_server.py` (one line: `sys.exit(0)` → `os._exit(0)` in `auto_shutdown`)
+- **Supersedes:** the pre-merge draft, which *assumed* #107 as an unmerged premise. This version was re-validated against the actual merged code.
+
+## Baseline (post-#107, verified in code)
+
+On a completion failure the merged system now does:
+
+- **Container** `complete_session` (`code_executor_server.py` L167–207): sets `is_complete = True` only **after** a confirmed `upload_to_s3` (L201, after L197); returns `bool`; a failed upload leaves `is_complete=False`. `/session/complete` returns HTTP 500 on failure.
+- **Controller** `complete_session`: retries the completion POST ×4; only calls `_cleanup_session` (ALB deregister + `ecs.stop_task`) after a confirmed HTTP 200; on exhaustion returns `{upload_completed: False}` **without** StopTask — the container is left alive.
+- **Coordinator** `cleanup_session` (`global_fargate_coordinator.py` L374–420): gates teardown on `upload_completed`; on failure keeps IP + session + HTTP client and early-returns.
+- **Container** `auto_shutdown` (boot + 1h, `code_executor_server.py` ~L881): `if not is_complete: complete_session()` (direct-to-S3 salvage), then `sys.exit(0)`.
+
+So the "failed flow" (keep-alive → salvage → reclaim gap) now genuinely exists. **Two gaps remain**, which this design closes:
+
+1. On the failure path the **ALB target + coordinator state (IP, session) leak** — nothing reclaims them (no reaper).
+2. `auto_shutdown`'s `sys.exit(0)` runs in a **daemon thread**, so it raises `SystemExit` only in that thread and does **not** terminate the process — the Fargate task never self-terminates on the failure path (empirically verified). The salvage upload runs, but the task lingers until externally stopped.
+
+## Changes
+
+### Change 0 — `os._exit` in `auto_shutdown` (container)
+`code_executor_server.py`, `auto_shutdown` (~L881): replace `sys.exit(0)` with `os._exit(0)` so the daemon-thread shutdown actually terminates the process (and the Fargate task) after the boot+1h salvage. `os._exit` is appropriate: the salvage upload has already run, all logs use `flush=True`, and the container has no critical atexit handlers. (This is the earlier commit `59dd18d`, now valid on the post-#107 baseline; re-applied on this branch.)
+
+### Tier 1 — deregister the ALB target on the failure path (coordinator)
+In `cleanup_session`'s upload-not-confirmed branch: `_deregister_from_alb(container_ip)` immediately. Safe because the salvage upload is a direct boto3→S3 call that does **not** use the ALB, so removing the target prevents a permanent zombie in the target group. Do **not** StopTask (the container must live to salvage). Record the orphan (see Tier 2) and keep the IP held.
+
+### Tier 2 — orphan tracking + reclaim-on-allocate sweep (coordinator)
+
+- **`_orphaned_sessions` dict — REVISED from the draft's in-place flag.** On the failure path, **move** the session record out of `_sessions` into `_orphaned_sessions[req_id] = {task_arn, container_ip, session_id, orphaned_at}` and **delete it from `_sessions`**. Keep the IP in `_used_container_ips` (the container still holds it).
+  - **Why moved, not flagged:** if the orphan stayed in `_sessions`, `ensure_session` (L224: `if req_id in self._sessions: return self._reuse_existing_session()`) would try to **reuse** it on a same-`request_id` retry — but Tier 1 removed its ALB target, so reuse would target a deregistered/dying container. Moving it out makes `ensure_session` create a **fresh** session instead, and gives the sweep a clean worklist. (Surfaced by the "think-it-over" pass and the review workflow.)
+- **`_is_tasks_stopped(task_arns) -> set(stopped_arns)` — REVISED: batched.** One `ecs.describe_tasks` call for up to 100 ARNs. Classify a task as stopped when `lastStatus == 'STOPPED'` **or** it is absent from the response (already gone). On any API error, treat all as **not** stopped (conservative — never reclaim while the container may still hold its IP).
+- **`_reclaim_stopped_orphans()`.** Batch-check every `_orphaned_sessions` entry; for each stopped one, reclaim: `_deregister_from_alb` (idempotent) + drop IP from `_used_container_ips` + drop `_http_clients[req_id]` + delete from `_orphaned_sessions` + add `req_id` to `_cleaned_up_requests`. Best-effort; log each reclaim; never raise into the request path.
+- **Hook.** `ensure_session()` calls `_reclaim_stopped_orphans()` at entry (once per request, before the reuse/create decision).
+
+## Error handling & concurrency
+- Sweep/helper are **best-effort** — never raise into the request path.
+- **Conservative reclaim** on unknown task status (do not free a held IP while unsure the task is dead).
+- **Lock-free safety:** the sweep only touches `_orphaned_sessions` whose task is `STOPPED`; active sessions live in `_sessions` and are `RUNNING`, so never eligible. A `list(...)` snapshot avoids "dict changed during iteration." No new race surface versus the existing lock-free code. A real concurrency fix (locking + background reaper) is Tier 3, out of scope.
+
+## Known limitations (documented, not fixed here)
+- **Salvage is best-effort:** `auto_shutdown` calls `complete_session()` then `os._exit(0)` unconditionally; a persistent S3 failure — or the task dying earlier (spot reclaim / OOM / crash) — still loses the report permanently. Inherent to ephemeral container storage.
+- **Out-of-band recovery:** a successful salvage lands in S3 up to ~1h after the user already saw a failure — it protects the artifact, not the live request UX.
+- **Absolute (not idle) 1h timer:** a failure early in a container's life leaves it alive up to ~57 min before the salvage retry and before the reclaim sweep can find it `STOPPED`.
+- **Unbounded until next request:** with no subsequent request, orphans linger in memory (bounded by process lifetime). The ALB target is already removed by Tier 1, so the AWS-side zombie is gone regardless.
+
+## Testing
+No test framework (per `CLAUDE.md`); mock-based like #107. Stub the ECS client / `_is_tasks_stopped` and assert:
+- `STOPPED` orphan → removed from `_orphaned_sessions` + `_used_container_ips` + `_http_clients`, added to `_cleaned_up_requests`, ALB deregister called.
+- `RUNNING` orphan → untouched.
+- `describe_tasks` error → nothing reclaimed.
+- `ensure_session` for a same `request_id` after tagging → creates a **fresh** session (does not reuse the orphan).
+- batched `describe_tasks` → a **single** call for N orphans.
+
+## Observability
+ERROR log when a session is orphaned; INFO on each reclaim. CloudWatch metric / leak cap: deferred (YAGNI).
+
+## Out of scope
+Tier 3 (background reaper thread, ALB↔task reconciliation for crash-orphans, singleton locking, metrics/cap). No further container changes beyond `os._exit`. The full review-workflow transcript (25 findings; 2 pre-#107 criticals now resolved by the merge) lives in the session's workflow journal.

--- a/managed-agentcore/fargate-runtime/code_executor_server.py
+++ b/managed-agentcore/fargate-runtime/code_executor_server.py
@@ -878,7 +878,11 @@ def auto_shutdown():
         session_manager.complete_session()
 
     time.sleep(10)  # Wait for S3 upload completion
-    sys.exit(0)
+    # os._exit (not sys.exit): auto_shutdown runs in a daemon thread, and
+    # sys.exit() only raises SystemExit in the *calling* thread — the Flask
+    # main thread keeps running, so the process (and the Fargate task) would
+    # never actually exit. os._exit forces the whole process to terminate.
+    os._exit(0)
 
 if __name__ == "__main__":
     print("=" * 60, flush=True)

--- a/managed-agentcore/src/tools/global_fargate_coordinator.py
+++ b/managed-agentcore/src/tools/global_fargate_coordinator.py
@@ -147,6 +147,8 @@ class GlobalFargateSessionManager:
     _sessions = {}  # {request_id: session_info} - Per-request session management
     _http_clients = {}  # {request_id: http_session} - Per-request HTTP client (cookie isolation)
     _used_container_ips = {}  # {container_ip: request_id} - IP-based container ownership tracking
+    # Failed-upload sessions kept alive for auto_shutdown salvage; reclaimed once their ECS task stops.
+    _orphaned_sessions = {}   # {request_id: {session_id, container_ip, task_arn, orphaned_at}}
     _current_request_id = None  # Current context request ID
     _session_creation_failures = {}  # {request_id: failure_count} - Session creation failure tracking
     _cleaned_up_requests = set()  # Cleaned-up request IDs (prevents recreation)
@@ -213,6 +215,11 @@ class GlobalFargateSessionManager:
         try:
             if not self._current_request_id:
                 raise Exception("Request context not set. Call set_request_context() first.")
+
+            # Reclaim any orphaned sessions whose Fargate task has now stopped
+            # (best-effort: frees IP/ALB/HTTP-client/session state left by a prior
+            # failed completion). Never blocks the request.
+            self._reclaim_stopped_orphans()
 
             # Prevent new session creation for already cleaned-up requests
             if self._current_request_id in self._cleaned_up_requests:
@@ -404,15 +411,28 @@ class GlobalFargateSessionManager:
                     del self._sessions[cleanup_request_id]
                     logger.info(f"✅ Session cleanup completed. Remaining sessions: {len(self._sessions)}")
                 else:
-                    # Upload NOT confirmed → leave the container registered and
-                    # alive so its 1-hour auto-shutdown can make a final upload
-                    # attempt. Do NOT delete the session here, so we don't lose
-                    # the ability to observe/retry it.
+                    # Upload NOT confirmed → keep the container ALIVE (do NOT StopTask)
+                    # so auto_shutdown can make a final direct-to-S3 salvage upload.
+                    # That salvage does NOT use the ALB, so:
+                    #   Tier 1: deregister the ALB target now → no permanent zombie target.
+                    #   Tier 2: move the record out of _sessions into _orphaned_sessions so a
+                    #           same-request_id retry creates a FRESH session (not a reuse of
+                    #           this doomed container); a later sweep reclaims the IP once the
+                    #           task actually stops. IP stays held until then.
+                    if container_ip:
+                        self._deregister_from_alb(container_ip)   # Tier 1 (idempotent)
+                    self._orphaned_sessions[cleanup_request_id] = {
+                        'session_id': session_info['session_id'],
+                        'container_ip': container_ip,
+                        'task_arn': session_info.get('fargate_session', {}).get('task_arn'),
+                        'orphaned_at': datetime.now(),
+                    }
+                    del self._sessions[cleanup_request_id]         # Tier 2: out of the reuse path
                     logger.error(
                         f"❌ S3 upload not confirmed for session "
                         f"{session_info['session_id']} (request {cleanup_request_id}). "
-                        f"Leaving container alive for auto-shutdown fail-safe retry; "
-                        f"skipping ALB deregister and session deletion."
+                        f"ALB target deregistered; container left alive for auto_shutdown salvage; "
+                        f"session moved to orphan list (IP {container_ip} held until its task stops)."
                     )
             else:
                 logger.warning(f"⚠️ No session found for request {cleanup_request_id}")
@@ -1123,6 +1143,76 @@ class GlobalFargateSessionManager:
         except Exception as alb_error:
             # Continue session cleanup even if ALB deregistration fails
             logger.warning(f"⚠️ Failed to deregister ALB target {container_ip}: {alb_error}")
+
+    def _is_tasks_stopped(self, task_arns):
+        """Return the set of task ARNs that are STOPPED (or no longer exist).
+
+        Batched: one ecs.describe_tasks call per 100 ARNs. On any API error,
+        returns an empty set (conservative — never reclaim a session while unsure
+        its container/IP is truly gone).
+        """
+        arns = [a for a in task_arns if a]
+        if not arns:
+            return set()
+        stopped = set()
+        try:
+            ecs_client = boto3.client('ecs', region_name=self._get_aws_region())
+            for i in range(0, len(arns), 100):          # describe_tasks: max 100 tasks/call
+                batch = arns[i:i + 100]
+                resp = ecs_client.describe_tasks(cluster=ECS_CLUSTER_NAME, tasks=batch)
+                present = set()
+                for t in resp.get('tasks', []):
+                    present.add(t['taskArn'])
+                    if t.get('lastStatus') == 'STOPPED':
+                        stopped.add(t['taskArn'])
+                for a in batch:                          # absent from response → already gone
+                    if a not in present:
+                        stopped.add(a)
+        except Exception as e:
+            logger.warning(f"⚠️ Could not query ECS task status for orphan reclaim: {e}")
+            return set()
+        return stopped
+
+    def _reclaim_stopped_orphans(self):
+        """Reclaim coordinator state for orphaned sessions whose task has stopped.
+
+        An orphan is a session whose final S3 upload could not be confirmed; its
+        container was left alive for the auto_shutdown salvage. Once that task
+        actually stops, its IP / ALB target / HTTP client / session record are
+        safe to reclaim. Best-effort: never raises into the request path.
+        """
+        if not self._orphaned_sessions:
+            return
+        try:
+            arns = [o.get('task_arn') for o in self._orphaned_sessions.values()]
+            stopped = self._is_tasks_stopped(arns)
+            for req_id in list(self._orphaned_sessions.keys()):
+                # Never reclaim the request currently starting up (would add it to
+                # _cleaned_up_requests and FATAL-block its own fresh session).
+                if req_id == self._current_request_id:
+                    continue
+                orphan = self._orphaned_sessions.get(req_id)
+                if not orphan:
+                    continue
+                task_arn = orphan.get('task_arn')
+                if not task_arn or task_arn not in stopped:
+                    continue                              # still running / unknown → leave it
+                ip = orphan.get('container_ip')
+                try:
+                    if ip:
+                        self._deregister_from_alb(ip)     # idempotent
+                        self._used_container_ips.pop(ip, None)
+                    self._http_clients.pop(req_id, None)
+                    self._orphaned_sessions.pop(req_id, None)
+                    self._cleaned_up_requests.add(req_id)
+                    logger.info(
+                        f"🧹 Reclaimed stopped orphan session {orphan.get('session_id')} "
+                        f"(request {req_id}, freed IP {ip})"
+                    )
+                except Exception as e:
+                    logger.warning(f"⚠️ Failed to reclaim orphan {req_id}: {e}")
+        except Exception as e:
+            logger.warning(f"⚠️ Orphan reclaim sweep failed: {e}")
 
     def _auto_cleanup(self):
         """Automatically clean up all sessions on program exit"""


### PR DESCRIPTION
## Problem

Builds on #107. When a session's final S3 upload cannot be confirmed, #107 correctly keeps the container alive for its `auto_shutdown` salvage — but leaves state behind that nothing reclaims:

- **ALB target** (AWS-side, permanent) → a zombie target that accumulates toward the target-group limit; a standalone task is not auto-deregistered by ECS.
- **`_used_container_ips` / `_sessions` / `_http_clients`** (in-memory) → leak; there is no reaper.
- **`auto_shutdown`'s `sys.exit(0)`** runs in a daemon thread, so it only raises `SystemExit` in that thread and never terminates the process — the task lingers even after the salvage.

## Changes

**Container — `code_executor_server.py`**
- `auto_shutdown`: `sys.exit(0)` → `os._exit(0)` so the daemon-thread shutdown actually terminates the process/task after the salvage. (`sys.exit` only raises `SystemExit` in the calling thread; the Flask main thread keeps running.)

**Coordinator — `global_fargate_coordinator.py`**
- **Tier 1:** on a failed completion, deregister the ALB target immediately. Safe because the salvage upload is a direct `boto3`→S3 call that does not use the ALB → no permanent zombie target.
- **Tier 2:** move the failed session out of `_sessions` into a new `_orphaned_sessions` dict (so a same-`request_id` retry creates a **fresh** session instead of reusing the deregistered/dying container), and reclaim it via `_reclaim_stopped_orphans()` — a best-effort sweep run at `ensure_session` entry that batches `ecs.describe_tasks` (one call per 100 ARNs) and frees IP / ALB / HTTP-client / session once the task is `STOPPED`. Conservative on API error; skips the request that is currently starting up.

## Testing

- `py_compile` clean on both files.
- Mock-based test **17/17** (imports the real coordinator with deps mocked): STOPPED orphan reclaimed; RUNNING untouched; ECS error → no reclaim (conservative); current-request skipped; batched `describe_tasks` (1 call, absent == stopped); same `request_id` → fresh session (no reuse).
- Full E2E requires an AWS deploy (Fargate / ECS / ALB) and is not run in this PR.

## Known limitations (see design spec)

Salvage is best-effort (a persistent S3 failure, or the task dying early, still loses the report); recovery is out-of-band (up to ~1h after the user already saw the failure); the 1h `auto_shutdown` timer is absolute and **doubles as the max-session-lifetime cap**, so it cannot simply be shortened — decoupling it is deferred. Tier 3 (background reaper, singleton locking, metrics/cap) is out of scope.

Design spec: `docs/superpowers/specs/2026-07-08-fargate-zombie-cleanup-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
