### PR TITLE
Address security scan findings (bandit / semgrep / repolinter)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+## Code of Conduct
+
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,16 @@
+MIT No Attribution
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
   <div align="center">
     <a href="https://github.com/aws-samples/aws-ai-ml-workshop-kr/graphs/commit-activity"><img alt="GitHub commit activity" src="https://img.shields.io/github/commit-activity/m/aws-samples/aws-ai-ml-workshop-kr"/></a>
-    <a href="https://github.com/aws-samples/aws-ai-ml-workshop-kr/blob/master/LICENSE"><img alt="License" src="https://img.shields.io/badge/LICENSE-MIT-green"/></a>
+    <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/LICENSE-MIT--0-green"/></a>
     <a href="https://www.python.org/downloads/"><img alt="Python" src="https://img.shields.io/badge/python-3.12+-blue.svg"/></a>
   </div>
 
@@ -167,7 +167,7 @@ git push origin feature/your-feature-name
 
 ## License
 
-This project is licensed under the **MIT License** - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the **MIT-0 License** - see the [LICENSE](LICENSE) file for details.
 
 ## Acknowledgments
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,10 @@
+## Reporting Security Issues
+
+We take all security reports seriously. When we receive such reports, we will
+investigate and subsequently address any potential vulnerabilities as quickly
+as possible.
+
+If you discover a potential security issue in this project, we ask that you notify
+AWS/Amazon Security via our [vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/)
+or directly via email to [aws-security@amazon.com](mailto:aws-security@amazon.com).
+Please do *not* create a public GitHub issue in this project.

--- a/deep-insight-web/chat_agent.py
+++ b/deep-insight-web/chat_agent.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import re
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -45,7 +46,11 @@ CHAT_MODEL_ID = os.environ.get(
 # schema) and tool specs are static across a session, so caching them yields
 # ~90% input-token savings on repeat turns. Set to "0" to disable for debugging.
 ENABLE_PROMPT_CACHE = os.environ.get("ENABLE_PROMPT_CACHE", "1") != "0"
-LOCAL_UPLOAD_DIR = Path("/tmp/deep-insight-uploads")
+# Upload root defaults to a path under the system temp dir; override with
+# UPLOAD_DIR when the container mounts a dedicated writable volume.
+LOCAL_UPLOAD_DIR = Path(
+    os.environ.get("UPLOAD_DIR", os.path.join(tempfile.gettempdir(), "deep-insight-uploads"))
+)
 
 # Strict allow-list for upload_id. CodeQL's path-injection taint analysis
 # recognizes regex.fullmatch on `^[allowed-chars]+$` as a sanitizer barrier;

--- a/managed-agentcore/fargate-runtime/Dockerfile
+++ b/managed-agentcore/fargate-runtime/Dockerfile
@@ -64,5 +64,11 @@ COPY code_executor_server.py .
 ENV PYTHONUNBUFFERED=1
 ENV ENV_NAME=production
 
+# Run as a non-root user. The executor writes to /app/data, /app/artifacts,
+# and /tmp/session_* at runtime, so grant ownership of /app to that user.
+RUN groupadd --system executor && useradd --system --gid executor --create-home executor \
+    && chown -R executor:executor /app
+USER executor
+
 # Run Python script when container starts
 CMD ["python", "-u", "code_executor_server.py"]

--- a/managed-agentcore/fargate-runtime/code_executor_server.py
+++ b/managed-agentcore/fargate-runtime/code_executor_server.py
@@ -110,6 +110,7 @@ import os
 import json
 import uuid
 import traceback
+import tempfile
 import threading
 import time
 import subprocess
@@ -134,7 +135,7 @@ class SessionManager:
         self.max_executions = 500
         self.start_time = datetime.now()
         self.is_complete = False
-        self.workspace = f"/tmp/session_{self.session_id}"
+        self.workspace = os.path.join(tempfile.gettempdir(), f"session_{self.session_id}")
         os.makedirs(self.workspace, exist_ok=True)
 
         # Create data and artifacts directories for file I/O

--- a/managed-agentcore/src/prompts/reporter.md
+++ b/managed-agentcore/src/prompts/reporter.md
@@ -182,8 +182,8 @@ NS_CT = 'http://schemas.openxmlformats.org/package/2006/content-types'
 SVG_EXT_URI = '{{96DAC541-7B7A-43D3-8B79-37D633B846F1}}'
 IMAGE_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image'
 
-def _sha1_file(path):
-    h = hashlib.sha1()
+def _sha256_file(path):
+    h = hashlib.sha256()
     with path.open('rb') as f:
         for chunk in iter(lambda: f.read(65536), b''):
             h.update(chunk)
@@ -200,7 +200,7 @@ def finalize_svg_embeddings(docx_path, artifacts_dir):
     for png_file in artifacts_dir.rglob('*.png'):
         svg_file = png_file.with_suffix('.svg')
         if svg_file.exists():
-            png_hash_to_svg[_sha1_file(png_file)] = svg_file
+            png_hash_to_svg[_sha256_file(png_file)] = svg_file
     if not png_hash_to_svg:
         return 0
     tmp_dir = Path(tempfile.mkdtemp(prefix='docx_svg_'))
@@ -212,7 +212,7 @@ def finalize_svg_embeddings(docx_path, artifacts_dir):
             return 0
         media_to_svg = {{}}
         for png_in_docx in media_dir.glob('*.png'):
-            docx_hash = _sha1_file(png_in_docx)
+            docx_hash = _sha256_file(png_in_docx)
             if docx_hash in png_hash_to_svg:
                 media_to_svg[png_in_docx.name] = png_hash_to_svg[docx_hash]
         if not media_to_svg:

--- a/managed-agentcore/src/utils/agentcore.py
+++ b/managed-agentcore/src/utils/agentcore.py
@@ -1,15 +1,30 @@
 import boto3
 import json
+import secrets
+import string
 import time
 from boto3.session import Session
+
+
+def _generate_password(length: int = 16) -> str:
+    """Generate a random password satisfying the pool's password policy."""
+    alphabet = string.ascii_letters + string.digits
+    return (
+        ''.join(secrets.choice(alphabet) for _ in range(length))
+        + secrets.choice(string.ascii_uppercase)
+        + secrets.choice(string.ascii_lowercase)
+        + secrets.choice(string.digits)
+        + secrets.choice('!@#$%^&*')
+    )
+
 
 def setup_cognito_user_pool():
     boto_session = Session()
     region = boto_session.region_name
-    
+
     # Initialize Cognito client
     cognito_client = boto3.client('cognito-idp', region_name=region)
-    
+
     try:
         # Create User Pool
         user_pool_response = cognito_client.create_user_pool(
@@ -34,29 +49,30 @@ def setup_cognito_user_pool():
         )
         client_id = app_client_response['UserPoolClient']['ClientId']
         
-        # Create User
+        # Create User with randomly generated credentials
+        test_password = _generate_password()
         cognito_client.admin_create_user(
             UserPoolId=pool_id,
             Username='testuser',
-            TemporaryPassword='Temp123!',
+            TemporaryPassword=_generate_password(),
             MessageAction='SUPPRESS'
         )
-        
+
         # Set Permanent Password
         cognito_client.admin_set_user_password(
             UserPoolId=pool_id,
             Username='testuser',
-            Password='MyPassword123!',
+            Password=test_password,
             Permanent=True
         )
-        
+
         # Authenticate User and get Access Token
         auth_response = cognito_client.initiate_auth(
             ClientId=client_id,
             AuthFlow='USER_PASSWORD_AUTH',
             AuthParameters={
                 'USERNAME': 'testuser',
-                'PASSWORD': 'MyPassword123!'
+                'PASSWORD': test_password
             }
         )
         bearer_token = auth_response['AuthenticationResult']['AccessToken']

--- a/managed-agentcore/src/utils/svg_docx.py
+++ b/managed-agentcore/src/utils/svg_docx.py
@@ -42,8 +42,8 @@ _SVG_EXT_URI = '{96DAC541-7B7A-43D3-8B79-37D633B846F1}'  # Microsoft standard SV
 _IMAGE_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image'
 
 
-def _sha1_file(path: Path) -> str:
-    h = hashlib.sha1()
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
     with path.open('rb') as f:
         for chunk in iter(lambda: f.read(65536), b''):
             h.update(chunk)
@@ -74,7 +74,7 @@ def finalize_svg_embeddings(docx_path: Union[str, Path], artifacts_dir: Union[st
     for png_file in artifacts_dir.rglob('*.png'):
         svg_file = png_file.with_suffix('.svg')
         if svg_file.exists():
-            png_hash_to_svg[_sha1_file(png_file)] = svg_file
+            png_hash_to_svg[_sha256_file(png_file)] = svg_file
 
     if not png_hash_to_svg:
         return 0
@@ -90,7 +90,7 @@ def finalize_svg_embeddings(docx_path: Union[str, Path], artifacts_dir: Union[st
 
         media_to_svg: dict[str, Path] = {}
         for png_in_docx in media_dir.glob('*.png'):
-            docx_hash = _sha1_file(png_in_docx)
+            docx_hash = _sha256_file(png_in_docx)
             if docx_hash in png_hash_to_svg:
                 media_to_svg[png_in_docx.name] = png_hash_to_svg[docx_hash]
 

--- a/managed-agentcore/src/utils/svg_docx.py
+++ b/managed-agentcore/src/utils/svg_docx.py
@@ -14,8 +14,8 @@ Usage (in reporter agent):
 The function is idempotent: re-running on an already-upgraded DOCX is a no-op.
 PNGs without a matching SVG sibling pass through unchanged.
 
-Matching strategy: each embedded PNG is hashed (SHA-1) and looked up against the
-SHA-1 of every PNG in artifacts_dir whose .svg sibling exists. This works
+Matching strategy: each embedded PNG is hashed (SHA-256) and looked up against the
+SHA-256 of every PNG in artifacts_dir whose .svg sibling exists. This works
 regardless of how python-docx renamed images during insertion.
 """
 from __future__ import annotations

--- a/self-hosted/src/prompts/reporter.md
+++ b/self-hosted/src/prompts/reporter.md
@@ -241,8 +241,8 @@ NS_CT = 'http://schemas.openxmlformats.org/package/2006/content-types'
 SVG_EXT_URI = '{{96DAC541-7B7A-43D3-8B79-37D633B846F1}}'
 IMAGE_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image'
 
-def _sha1_file(path):
-    h = hashlib.sha1()
+def _sha256_file(path):
+    h = hashlib.sha256()
     with path.open('rb') as f:
         for chunk in iter(lambda: f.read(65536), b''):
             h.update(chunk)
@@ -259,7 +259,7 @@ def finalize_svg_embeddings(docx_path, artifacts_dir):
     for png_file in artifacts_dir.rglob('*.png'):
         svg_file = png_file.with_suffix('.svg')
         if svg_file.exists():
-            png_hash_to_svg[_sha1_file(png_file)] = svg_file
+            png_hash_to_svg[_sha256_file(png_file)] = svg_file
     if not png_hash_to_svg:
         return 0
     tmp_dir = Path(tempfile.mkdtemp(prefix='docx_svg_'))
@@ -271,7 +271,7 @@ def finalize_svg_embeddings(docx_path, artifacts_dir):
             return 0
         media_to_svg = {{}}
         for png_in_docx in media_dir.glob('*.png'):
-            docx_hash = _sha1_file(png_in_docx)
+            docx_hash = _sha256_file(png_in_docx)
             if docx_hash in png_hash_to_svg:
                 media_to_svg[png_in_docx.name] = png_hash_to_svg[docx_hash]
         if not media_to_svg:

--- a/self-hosted/src/utils/svg_docx.py
+++ b/self-hosted/src/utils/svg_docx.py
@@ -42,8 +42,8 @@ _SVG_EXT_URI = '{96DAC541-7B7A-43D3-8B79-37D633B846F1}'  # Microsoft standard SV
 _IMAGE_REL_TYPE = 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image'
 
 
-def _sha1_file(path: Path) -> str:
-    h = hashlib.sha1()
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
     with path.open('rb') as f:
         for chunk in iter(lambda: f.read(65536), b''):
             h.update(chunk)
@@ -74,7 +74,7 @@ def finalize_svg_embeddings(docx_path: Union[str, Path], artifacts_dir: Union[st
     for png_file in artifacts_dir.rglob('*.png'):
         svg_file = png_file.with_suffix('.svg')
         if svg_file.exists():
-            png_hash_to_svg[_sha1_file(png_file)] = svg_file
+            png_hash_to_svg[_sha256_file(png_file)] = svg_file
 
     if not png_hash_to_svg:
         return 0
@@ -90,7 +90,7 @@ def finalize_svg_embeddings(docx_path: Union[str, Path], artifacts_dir: Union[st
 
         media_to_svg: dict[str, Path] = {}
         for png_in_docx in media_dir.glob('*.png'):
-            docx_hash = _sha1_file(png_in_docx)
+            docx_hash = _sha256_file(png_in_docx)
             if docx_hash in png_hash_to_svg:
                 media_to_svg[png_in_docx.name] = png_hash_to_svg[docx_hash]
 

--- a/self-hosted/src/utils/svg_docx.py
+++ b/self-hosted/src/utils/svg_docx.py
@@ -14,8 +14,8 @@ Usage (in reporter agent):
 The function is idempotent: re-running on an already-upgraded DOCX is a no-op.
 PNGs without a matching SVG sibling pass through unchanged.
 
-Matching strategy: each embedded PNG is hashed (SHA-1) and looked up against the
-SHA-1 of every PNG in artifacts_dir whose .svg sibling exists. This works
+Matching strategy: each embedded PNG is hashed (SHA-256) and looked up against the
+SHA-256 of every PNG in artifacts_dir whose .svg sibling exists. This works
 regardless of how python-docx renamed images during insertion.
 """
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Security scan remediation for the Public Content Security Review (PCSR) required by the TCX Blogs review process (ML-21081 / ML-21082 / ML-21083, Step 4: Security review).

Scanners run on commit 98c4f6a: **bandit 1.9.4**, **semgrep 1.168.0** (`--config auto`), **repolinter 0.12.0**.

## Changes

### Repository compliance (repolinter)
- Add `LICENSE` (MIT-0) — README referenced a LICENSE file that did not exist in this repo
- Add `CODE_OF_CONDUCT.md` and `SECURITY.md` per aws-samples repository standards
- Point README license badge/section to this repo's own LICENSE (was linking to aws-ai-ml-workshop-kr)

### Container hardening (semgrep ERROR: dockerfile.security.missing-user)
- `managed-agentcore/fargate-runtime/Dockerfile`: run as non-root `executor` user; `chown /app` so runtime writes to `/app/data`, `/app/artifacts` keep working

### Code fixes (bandit)
- **B324** SHA-1 → SHA-256 for PNG fingerprinting in `svg_docx.py` (both deployments), including the verbatim helper snippets embedded in `reporter.md` prompts and module docstrings
- **B105/B106** Replace hardcoded Cognito test passwords with `secrets`-generated random credentials (`managed-agentcore/src/utils/agentcore.py`)
- **B108** Derive temp workspace/upload paths from `tempfile.gettempdir()` instead of hardcoded `/tmp` (`code_executor_server.py`, `chat_agent.py`; upload root overridable via `UPLOAD_DIR`)

## Not changed (by design — documented for the security review)
- `shell=True` / `exec` in bash/code execution tools: core sandboxed-execution feature; mitigated by per-session Fargate container isolation, restricted builtins, and execution timeouts
- B608 SQL string construction in `chat_agent.py`: Text2SQL feature; mitigated by session-scoped DuckDB `:memory:` instances
- `0.0.0.0` binds: containers run behind ALB in private VPC

## Verification
- `python -m py_compile` passes on all modified files
- bandit re-scan: High findings reduced 5 → 3 (remaining 3 are the by-design B602 items above); B324/B105/B106/B108 cleared
- repolinter re-scan: license/code-of-conduct/security checks now pass